### PR TITLE
Space Skype Scene Tweak

### DIFF
--- a/includes/follower.anno.as
+++ b/includes/follower.anno.as
@@ -2755,7 +2755,7 @@ public function grayGooArrivesAtShip():void
 
 public function grayGooSpessSkype():void
 {
-	if (flags["ANNO_NOVA_UPDATE"] == 3 && flags["GRAYGOO_SPESS_SKYPE"] == undefined && rand(5) == 0)
+	if (hasGooArmor() && flags["ANNO_NOVA_UPDATE"] == 3 && flags["GRAYGOO_SPESS_SKYPE"] == undefined && rand(5) == 0)
 	{
 		flags["GRAYGOO_SPESS_SKYPE"] = 1;
 		eventQueue.push(grayGooSpessSkypeScene);
@@ -2789,4 +2789,18 @@ public function grayGooSpessSkypeScene():void
 	output("\n\nThe screen flicks off to back, and like breathing a sigh, [goo.name] resumes her less-human gooey form. She scoots back over to where you’ve dumped your equipment and collapses into an amorphous pile, awaiting you. Smiling to yourself, you roll back over and go to sleep again...");
 
 	addButton(0, "Next", mainGameMenu);
+}
+
+public function hasGooArmor():Boolean
+{
+    if(pc.armor is GooArmor || pc.hasItemByName("Goo Armor")) return true;
+    if(currentLocation == "SHIP INTERIOR")
+    {
+        for (var i:int = 0; i < pc.ShipStorageInventory.length; i++)
+        {
+            var sItem:ItemSlotClass = pc.ShipStorageInventory[i] as ItemSlotClass;
+            if (sItem.shortName == "Goo Armor" && sItem.quantity >= 1) return true;
+        }
+    }
+    return false;
 }


### PR DESCRIPTION
If the suit is nowhere to be found on the character or in the ship's inventory, how does this scene happen? (It is possible to sell her away to another vendor for 0 credits and she is not flagged as a quest item to protect from that.) Maybe add an item check for it!
