### PR TITLE
Remove the status effect managing pregnancy events for Queen of the D…

### DIFF
--- a/classes/DataManager/DataManager.as
+++ b/classes/DataManager/DataManager.as
@@ -1400,6 +1400,12 @@
 				{
 					kGAMECLASS.flags["LANE_BROKEN_INCOMINGSAVE"] = 1;
 				}
+				
+				// Hacking in a cleanup check for some pregnancy data because :effort: to do this without actual instantiated objects
+				if (!kGAMECLASS.pc.hasPregnancyOfType("DeepQueenPregnancy") && kGAMECLASS.pc.hasStatusEffect("Queen Pregnancy State"))
+				{
+					kGAMECLASS.pc.removeStatusEffect("Queen Pregnancy State");
+				}
 			}
 			
 			kGAMECLASS.mainGameMenu();

--- a/classes/GameData/Pregnancy/BasePregnancyHandler.as
+++ b/classes/GameData/Pregnancy/BasePregnancyHandler.as
@@ -117,7 +117,6 @@ package classes.GameData.Pregnancy
 						if (this.alwaysImpregnate || mother.fertility() > Math.floor(Math.random() * this.basePregnancyChance))
 						{
 							mother.fertilizeEggs();
-							return true;
 						}
 					}
 				}
@@ -262,6 +261,12 @@ package classes.GameData.Pregnancy
 				}
 				
 				if (thisPtr.debugTrace) trace("Autosetting pregnancy to slot " + pregSlot);
+			}
+			
+			// Fail if the targetted hole is already pregnant
+			if ((mother.pregnancyData[pregSlot] as PregnancyData).pregnancyType != "")
+			{
+				return false;
 			}
 			
 			// Process various ignore values

--- a/classes/GameData/Pregnancy/Handlers/VenusPitcherSeedCarrierPregnancyHandler.as
+++ b/classes/GameData/Pregnancy/Handlers/VenusPitcherSeedCarrierPregnancyHandler.as
@@ -53,7 +53,10 @@ package classes.GameData.Pregnancy.Handlers
 				if (pregSlot == -1) return false;
 			}
 			
-			return true;
+			// If the hole we're trying to impregnate is already full and isn't the base type or empty, fail
+			var pData:PregnancyData = mother.pregnancyData[pregSlot];
+			if (pData.pregnancyType.length == 0 || pData.pregnancyType == "VenusPitcherSeedCarrier") return true;
+			return false;
 		}
 		
 		public static function seedCarrierOnSuccessfulImpregnation(father:Creature, mother:Creature, pregSlot:int, thisPtr:BasePregnancyHandler):void


### PR DESCRIPTION
…eep if the pregnancy isn't present on the player

Minor addition to default pregnancy handling code to avoid overwriting running types where not appropriate (fug u venus pitchers)
