### PR TITLE
Added extra gooball for crystal goos

### DIFF
--- a/classes/Characters/CrystalGooT1.as
+++ b/classes/Characters/CrystalGooT1.as
@@ -78,7 +78,7 @@ package classes.Characters
 			shield = new BasicShield();
 			shield.shields = 80;
 			baseShieldKineticResistance = shield.resistances.kinetic.resistanceValue = 25.0;
-			
+			shield.resistances.addFlag(DamageFlag.CRYSTALGOOARMOR);
 			shield.hasRandomProperties = true;
 			
 			this.physiqueRaw = 20;
@@ -156,14 +156,20 @@ package classes.Characters
 		
 		override public function get bustDisplay():String
 		{
-			if (shields() > 0) return "CRYSTAL_GOO_ARMORED";
-			else return "CRYSTAL_GOO_UNARMORED";
+			// Shit out a string like CRYSTAL_GOO_T1_RED or CRYSTAL_GOO_T1_RED_UNAMORED
+			return "CRYSTAL_GOO_T1_"+skinTone.toUpperCase() + (hasStatusEffect("Unarmored") ? "_UNARMORED" : "");
 		}
 		
 		public function Randomise():void
 		{
-			if(rand(2) == 0) skinTone = "green";
-			else skinTone = "blue";
+			var colours:Array = [];
+			colours.push( { v: "green", w: 39 } );
+			colours.push( { v: "blue", w: 25 } );
+			colours.push( { v: "yellow", w: 20 } );
+			colours.push( { v: "pink", w: 15 } );
+			colours.push( { v: "red", w: 1 } );
+			
+			skinTone = weightedRand(colours);
 			
 			UpdateState();
 		}
@@ -205,6 +211,8 @@ package classes.Characters
 			shield.resistances.kinetic.resistanceValue = MathUtil.LinearInterpolate(0, 1, shields() / shieldsMax()) * baseShieldKineticResistance;
 		}
 		
+		private var _hasChangedColour:Boolean = false;
+		
 		override public function OnTakeDamage(incomingDamage:TypeCollection):void
 		{
 			if (shields() <= 0)
@@ -233,6 +241,43 @@ package classes.Characters
 				if (incomingDamage.kinetic.damageValue > 0)
 				{
 					OnTakeDamageOutput = "The ganrael’s rounded gauntlets deflect some of the force!";
+				}
+			}
+			
+			if (skinTone == "green" || skinTone == "pink")
+			{
+				if (incomingDamage.electric.damageValue > 0)
+				{
+					if (OnTakeDamageOutput == null) OnTakeDamageOutput = "";
+					else OnTakeDamageOutput += "\n\n";
+					
+					OnTakeDamageOutput += "The ganrael’s body spasms from the electrical current, and jagged purple scores follow the paths of the arcing bolts!";
+					skinTone = "purple";
+					_hasChangedColour = true;
+				}
+			}
+			else if (skinTone == "blue" || skinTone == "red")
+			{
+				if (incomingDamage.freezing.damageValue > 0)
+				{
+					if (OnTakeDamageOutput == null) OnTakeDamageOutput = "";
+					else OnTakeDamageOutput += "\n\n";
+					
+					OnTakeDamageOutput += "A splotch of light orange color appears at the locus of your freezing attack, and spreads out as the ganrael shivers!";
+					skinTone = "orange";
+					_hasChangedColour = true;
+				}
+			}
+			else if (skinTone == "yellow")
+			{
+				if (incomingDamage.burning.damageValue > 0)
+				{
+					if (OnTakeDamageOutput == null) OnTakeDamageOutput = "";
+					else OnTakeDamageOutput += "\n\n";
+					
+					OnTakeDamageOutput += "The ganrael’s body burns a scarlet, angry red where your thermal attack struck, not only outside but inside as well!";
+					skinTone = "red";
+					_hasChangedColour = true;
 				}
 			}
 		}

--- a/classes/Characters/CrystalGooT2.as
+++ b/classes/Characters/CrystalGooT2.as
@@ -13,6 +13,8 @@ package classes.Characters
 	import classes.Items.Miscellaneous.EmptySlot;
 	import classes.Items.Protection.BasicShield;
 	import classes.Items.Protection.JoyCoPremiumShield;
+	import classes.Items.Transformatives.GooBallBlue;
+	import classes.Items.Transformatives.GooBallGreen;
 	import classes.ItemSlotClass;
 	import classes.kGAMECLASS;
 	import classes.Engine.Utility.rand;
@@ -71,6 +73,13 @@ package classes.Characters
 			
 			armor = new GooeyCoverings();
 			armor.defense = 10;
+			armor.resistances.burning.resistanceValue = 10.0;
+			armor.resistances.freezing.resistanceValue = -10.0;
+			armor.resistances.electric.resistanceValue = -30.0;
+			armor.resistances.drug.resistanceValue = -30.0;
+			armor.resistances.poison.resistanceValue = -30.0;
+			armor.resistances.kinetic.resistanceValue = 15.0;
+			
 			armor.hasRandomProperties = true;
 			
 			this.rangedWeapon = new EmptySlot();
@@ -78,7 +87,15 @@ package classes.Characters
 			shield = new BasicShield();
 			shield.shields = 100;
 			baseShieldKineticResistance = shield.resistances.kinetic.resistanceValue = 25.0;
+			shield.resistances.electric.resistanceValue = 50.0;
+			shield.resistances.burning.resistanceValue = 30.0;
+			shield.resistances.freezing.resistanceValue = 30.0;
+			shield.resistances.poison.resistanceValue = 100.0;
+			shield.resistances.drug.resistanceValue = 100.0;
 			shield.hasRandomProperties = true;
+			shield.resistances.addFlag(DamageFlag.CRYSTALGOOARMOR);
+			
+
 			
 			this.physiqueRaw = 30;
 			baseReflexes = reflexesRaw = 19;
@@ -155,14 +172,19 @@ package classes.Characters
 		
 		override public function get bustDisplay():String
 		{
-			if (shields() > 0) return "CRYSTAL_GOO_T2_ARMORED";
-			else return "CRYSTAL_GOO_T2_UNARMORED";
+			return "CRYSTAL_GOO_T2_"+skinTone.toUpperCase() + (hasStatusEffect("Unarmored") ? "_UNARMORED" : "");
 		}
 		
 		public function Randomise():void
 		{
-			if(rand(2) == 0) skinTone = "green";
-			else skinTone = "blue";
+			var colours:Array = [];
+			colours.push( { v: "green", w: 39 } );
+			colours.push( { v: "blue", w: 25 } );
+			colours.push( { v: "yellow", w: 20 } );
+			colours.push( { v: "pink", w: 15 } );
+			colours.push( { v: "red", w: 1 } );
+			
+			skinTone = weightedRand(colours);
 			
 			UpdateState();
 		}
@@ -195,8 +217,10 @@ package classes.Characters
 			shield.resistances.kinetic.resistanceValue = MathUtil.LinearInterpolate(0, 1, shields() / shieldsMax()) * baseShieldKineticResistance;
 		}
 		
+		private var _hasChangedColour:Boolean = false;
+		
 		override public function OnTakeDamage(incomingDamage:TypeCollection):void
-		{
+		{			
 			if (shields() <= 0)
 			{
 				if (!hasStatusEffect("Unarmored")) 
@@ -216,6 +240,43 @@ package classes.Characters
 						if (incomingDamage.burning.damageValue > 0) OnTakeDamageOutput = "The scorched flesh hisses and bubbles at the site of the damage, hardening into a jagged, scar-like plate!";
 						else OnTakeDamageOutput = "The cold causes hundreds of tiny crystals to form, clouding and stiffening the site into a sandpapery plate!";
 					}
+				}
+			}
+			
+			if (skinTone == "green" || skinTone == "pink")
+			{
+				if (incomingDamage.electric.damageValue > 0)
+				{
+					if (OnTakeDamageOutput == null) OnTakeDamageOutput = "";
+					else OnTakeDamageOutput += "\n\n";
+					
+					OnTakeDamageOutput += "The ganrael’s body spasms from the electrical current, and jagged purple scores follow the paths of the arcing bolts!";
+					skinTone = "purple";
+					_hasChangedColour = true;
+				}
+			}
+			else if (skinTone == "blue" || skinTone == "red")
+			{
+				if (incomingDamage.freezing.damageValue > 0)
+				{
+					if (OnTakeDamageOutput == null) OnTakeDamageOutput = "";
+					else OnTakeDamageOutput += "\n\n";
+					
+					OnTakeDamageOutput += "A splotch of light orange color appears at the locus of your freezing attack, and spreads out as the ganrael shivers!";
+					skinTone = "orange";
+					_hasChangedColour = true;
+				}
+			}
+			else if (skinTone == "yellow")
+			{
+				if (incomingDamage.burning.damageValue > 0)
+				{
+					if (OnTakeDamageOutput == null) OnTakeDamageOutput = "";
+					else OnTakeDamageOutput += "\n\n";
+					
+					OnTakeDamageOutput += "The ganrael’s body burns a scarlet, angry red where your thermal attack struck, not only outside but inside as well!";
+					skinTone = "red";
+					_hasChangedColour = true;
 				}
 			}
 		}

--- a/classes/Engine/Combat/DamageTypes/DamageFlag.as
+++ b/classes/Engine/Combat/DamageTypes/DamageFlag.as
@@ -38,6 +38,7 @@ package classes.Engine.Combat.DamageTypes
 		public static const GREATER_DRAINING:uint = 20; //Steals 90% of shield damage dealt
 		public static const VAMPIRIC:uint 		= 21; //Steals 50% of HP damage dealt.
 		public static const GREATER_VAMPIRIC:uint = 22; //Steals 90% of HP damage dealt
+		public static const CRYSTALGOOARMOR:uint = 23;
 		
 		public static const FlagNames:Array = [];
 		
@@ -66,6 +67,7 @@ package classes.Engine.Combat.DamageTypes
 			FlagNames[GREATER_DRAINING] 	= "Greater Draining";
 			FlagNames[VAMPIRIC] 			= "Vampiric";
 			FlagNames[GREATER_VAMPIRIC] 	= "Greater Vampiric";
+			FlagNames[CRYSTALGOOARMOR]		= "Crystal Goo Armor";
 		}
 		
 		private var _thisFlag:uint;

--- a/classes/Engine/Combat/calculateShieldDamage.as
+++ b/classes/Engine/Combat/calculateShieldDamage.as
@@ -27,6 +27,13 @@ package classes.Engine.Combat
 		// Get shield resistances from the target, and used them to reduce the damage available
 		var damageToShields:TypeCollection = damageResult.remainingDamage.makeCopy();
 		
+		// If this is crystal goo armor, store the base elec damage before resistances...
+		var cgooElecDamage:Number;
+		if (tarResistances.hasFlag(DamageFlag.CRYSTALGOOARMOR))
+		{
+			cgooElecDamage = damageToShields.electric.damageValue;
+		}
+		
 		// Store the total damage before and after resistances -- we'll use this to try and approximate how
 		// much damage we used to break through the shields if we get all the way through
 		var initialTotalDamage:Number = damageToShields.getTotal();
@@ -61,6 +68,13 @@ package classes.Engine.Combat
 			
 			damageResult.remainingDamage = new TypeCollection();
 			
+			// if goo armor, pump on some elec damage back to pass through to hp
+			if (tarResistances.hasFlag(DamageFlag.CRYSTALGOOARMOR))
+			{
+				// outgoing = incoming elec - elec damage after resistances = 100% of damage split across armor and hp
+				damageResult.remainingDamage.electric.damageValue = cgooElecDamage - damageResult.typedShieldDamage.electric.damageValue;
+			}
+			
 			target.shieldsRaw -= damageAfterResistances;
 			
 			return;
@@ -78,6 +92,12 @@ package classes.Engine.Combat
 			
 			damageResult.totalDamage = target.shieldsRaw;
 			damageResult.typedTotalDamage = damageResult.typedShieldDamage.makeCopy();
+			
+			// if goo armor, slap some elec back in the pot
+			if (tarResistances.hasFlag(DamageFlag.CRYSTALGOOARMOR))
+			{
+				damageResult.remainingDamage.electric.damageValue += cgooElecDamage - damageResult.typedShieldDamage.electric.damageValue;
+			}
 			
 			target.shieldsRaw = 0;
 		}

--- a/classes/Items/Miscellaneous/HorsePill.as
+++ b/classes/Items/Miscellaneous/HorsePill.as
@@ -791,15 +791,15 @@
 				//#8 Change hair color to black, brown, chestnut, or white (rare)
 				else if(select == 8)
 				{
-					var newHairColour:String = "";
-					if(rand(10) == 0) newHairColour = "white";
-					else if(rand(3) == 0) newHairColour = "chestnut";
-					else if(rand(2) == 0) newHairColour = "brown";
-					else newHairColour = "black";
+					var newhairColor:String = "";
+					if(rand(10) == 0) newhairColor = "white";
+					else if(rand(3) == 0) newhairColor = "chestnut";
+					else if(rand(2) == 0) newhairColor = "brown";
+					else newhairColor = "black";
 					
-					if (target.hairColorUnlocked(newHairColour))
+					if (target.hairColorUnlocked(newhairColor))
 					{
-						target.hairColor = newHairColour;
+						target.hairColor = newhairColor;
 						
 						//Bald
 						if(!target.hasHair()) kGAMECLASS.eventBuffer += "Your scalp tingles, but without any hair there, you aren't aware of what changed. Perhaps it changed your hair color, but you can't be sure until you grow some!";

--- a/classes/Items/Transformatives/GooBallGreen.as
+++ b/classes/Items/Transformatives/GooBallGreen.as
@@ -37,6 +37,7 @@
 			TooltipManager.addTooltip(this.shortName, this.tooltip);
 			
 			this.attackVerb = "";
+			addFlag(GLOBAL.NOT_CONSUMED_BY_DEFAULT);
 			
 			//Information
 			this.basePrice = 70;
@@ -52,38 +53,203 @@
 			this.version = this._latestVersion;
 		}
 		
-		protected function rand(max: Number): Number {
- 			return int(Math.random() * max);
- 		}
+		private function GooballUsed(target:Creature):void
+		{
+			target.destroyItemByType(GooBallGreen);
+			
+			clearMenu();
+			addButton(0, "Next", kGAMECLASS.useItemFunction);
+		}
+		
+		private function DoSpikehawk(target:Creature):void
+		{
+			clearOutput();
+			output("You apply the gel to your mohawk and pinch it into four vicious, punk spikes. The devil on your shoulder is going to get a poke in the eye next time you turn your head.");
+			target.hairStyle = "spikehawk";
+			
+			if (target.hairType == GLOBAL.HAIR_TYPE_GOO && target.hairColor != "green")
+			{
+				output(" The gel’s color also bleeds through, turning the points green.");
+				target.hairColor = "green";
+			}
+			
+			GooballUsed(target);
+		}
+		
+		private function DoQuiff(target:Creature):void
+		{
+			clearOutput();
+			output("You slather gel into your " + target.hairDescript(true, true) +" and, when it begins to harden, put it up into a big, tapered point! Your fans will adore it.");
+			target.hairStyle = "quiff";
+			
+			if (target.hairType == GLOBAL.HAIR_TYPE_GOO && target.hairColor != "green")
+			{
+				output(" The color also swamps your gooey locks, turning them green.");
+				target.hairColor = "green";
+			}
+			
+			GooballUsed(target);
+		}
+		
+		private function DoRinglets(target:Creature):void
+		{
+			clearOutput();
+			output("You slather your " + target.hairDescript(true, true) +" one lock at a time and twist it around your fingers. The gel");
+			target.hairStyle = "ringlets";
+			
+			if (target.hairType == GLOBAL.HAIR_TYPE_GOO && target.hairColor != "green")
+			{
+				output(" bleeds color through your goopy drape and");
+				target.hairColor = "green";
+			}
+			
+			output(" hardens your ‘do into" + target.hairColor + ", bouncy ringlets. Cute!");
+			
+			GooballUsed(target);
+		}
+		
+		private function DoCurtains(target:Creature):void
+		{
+			clearOutput();
+			output("You smear gel onto your antennae and then stick your bangs to them. The gel hardens, and you can move them to open your hair like drapes. Now you can flash people with your face!");
+			target.hairStyle = "curtains";
+			
+			if (target.hairType == GLOBAL.HAIR_TYPE_GOO) target.hairColor = "green";
+			else if (target.hairType == GLOBAL.HAIR_TYPE_TENTACLES) output(" Well, you could before, but now it looks theatrical.");
+			
+			GooballUsed(target);
+		}
+		
+		private function DoFingerwave(target:Creature):void
+		{
+			clearOutput();
+			output("You rub the gel into your " + target.hairDescript(true, true) +" and crimp it into waves for a classy, classic look.");
+			target.hairStyle = "fingerwave";
+			
+			if (target.hairType == GLOBAL.HAIR_TYPE_GOO && target.hairColor != "green")
+			{
+				output(" The gel’s color also spreads, turning your gooey locks green.");
+				target.hairColor = "green";
+			}
+			output(" <i>Très chic</i>.");
+			
+			GooballUsed(target);
+		}
+		
+		private function DoTopknot(target:Creature):void
+		{
+			clearOutput();
+			output("You apply the gel to your " + target.hairDescript(true, true) + " and then pin it up in a tight topknot. It’s solid enough to anchor a helmet");
+			target.hairStyle = "topknot";
+			if (target.hairType == GLOBAL.HAIR_TYPE_FEATHERS)
+			{
+				output(", and you even fan the tips of your feathers into a gingko leaf shape");
+			}
+			output("!");
+			
+			if (target.hairType == GLOBAL.HAIR_TYPE_GOO && target.hairColor != "green")
+			{
+				output(" The ball’s color also swamps your own, changing your hair to green.");
+				target.hairColor = "green";
+			}
+			
+			GooballUsed(target);
+		}
+		
+		private function DyeHair(target:Creature):void
+		{
+			clearOutput();
+			output("You carefully work the gel into your " + target.hairDescript(true, false) +", doing your utmost not to disturb your hairstyle in the process. In a matter of seconds your locks begin to soak up the shade of the gel, changing your hair to green.");
+			target.hairColor = "green";
+			
+			GooballUsed(target);
+		}
+		
+		private function DyeBody(target:Creature):void
+		{
+			clearOutput();
+			output("You stare down the glob like a horse pill and then throw it in your hatch. It feels like swallowing cotton. By the time it reaches your chest, it’s already begun to leak a cloud of color which radiates all over, making you stiff and slightly numb. <b>When full sensation comes back, your skin is green!</b>");
+			
+			target.skinTone = "green";
+			
+			GooballUsed(target);
+		}
 		
 		//METHOD ACTING!
 		override public function useFunction(target:Creature, usingCreature:Creature = null):Boolean
 		{
 			kGAMECLASS.clearOutput();
 			author("Gardeford");
-			if(target is PlayerCharacter) {
-				//pc is human
-				if(target.hairType != GLOBAL.HAIR_TYPE_GOO)
+			if (target is PlayerCharacter) 
+			{
+				output("You consider the blob of ganrael goo, which has formed a slight crust on its surface. If you wanted, you could probably smear it on something to stiffen it... your hair, for example.");
+				if (target.hairType == GLOBAL.HAIR_TYPE_GOO)
 				{
-					output("You rub the ball of goo ");
-					if(target.hasHair()) output("into your [pc.hair]");
-					else output("onto your scalp");
-					output(". You stand for a moment, waiting for something to happen. Eventually you realize that nothing is going to happen, and you've just rubbed a wad of goo all over your head...");
+					output(" It’d probably change your color if you did, since your hair is also goo.");
+					if (target.skinType == GLOBAL.SKIN_TYPE_GOO || target.hasSkinFlag(GLOBAL.FLAG_GOOEY)) output(" For that matter, it’d work on your body, too.");
 				}
-				//pc is goo
-				else
+				else if (target.skinType == GLOBAL.SKIN_TYPE_GOO || target.hasSkinFlag(GLOBAL.FLAG_GOOEY)) output(" It’d probably change the color of your body too, since your skin is gooey.");
+				
+				clearMenu();
+				if (target.hairStyle != "spikehawk")
 				{
-					output("You rub the ball of goo ");
-					if(target.hasHair()) output("into your [pc.hair]");
-					else output("onto your scalp");
-					output(", smiling widely when it's color changes to match the ball's. Using your codex's mirror function, you admire the new color, striking a few cool poses to test it out.");
-					target.hairColor = "green";
+					if (target.hairStyle == "mohawk") addButton(0, "Spikehawk", DoSpikehawk, target, "Spikey Mohawk", "Shape your mohawk into a spikehawk.");
+					else addDisabledButton(0, "Spikehawk", "Spikey Mohawk", "You don’t have a mohawk to spike.");
 				}
+				else addDisabledButton(0, "Spikehawk", "Spikey Mohawk", "Your hair is currently styled like this!");
+				
+				if (target.hairStyle != "quiff")
+				{
+					if (target.hairLength >= 5) addButton(1, "Quiff", DoQuiff, target, "Quiff", "Shape your hair into a single sleek, tapered point.");
+					else addDisabledButton(1, "Quiff", "Quiff", "Your hair’s too short for this style.");
+				}
+				else addDisabledButton(1, "Quiff", "Quiff", "Your hair is currently styled like this!");
+				
+				if (target.hairStyle != "ringlets")
+				{
+					if (target.hairLength >= 10) addButton(2, "Ringlets", DoRinglets, target, "Ringlets", "Shape your hair into helical loops.");
+					else addDisabledButton(2, "Ringlets", "Ringlets", "Your hair’s too short for this style.");
+				}
+				else addDisabledButton(2, "Ringlets", "Ringlets", "Your hair is currently styled like this!");
+				
+				if (target.hairStyle != "curtains")
+				{
+					if (target.hairLength >= 10 && target.hasAntennae()) addButton(3, "Curtains", DoCurtains, target, "Curtains", "Glue your bangs to your antennae and make curtains you can wave around.");
+					else if (target.hairLength < 10) addDisabledButton(3, "Curtains", "Curtains", "You don’t have long enough hair.");
+					else addDisabledButton(3, "Curtains", "Curtains", "You don’t have antennae.");
+				}
+				else addDisabledButton(3, "Curtains", "Curtains", "Your hair is currently styled like this!");
+				
+				if (target.hairStyle != "fingerwave")
+				{
+					addButton(4, "Fingerwave", DoFingerwave, target, "Fingerwave", "Shape your hair into a wavy, close bob.");
+				}
+				else addDisabledButton(4, "Fingerwave", "Fingerwave", "Your hair is currently styled like this!");
+				
+				if (target.hairStyle != "topknot")
+				{
+					if (target.hairLength <= 6) addButton(5, "Topknot", DoTopknot, target, "Topknot", "Put your hair up in an ironclad topknot.");
+					else addDisabledButton(5, "Topknot", "Topknot", "You have too much hair for this style.");
+				}
+				else addDisabledButton(5, "Topknot", "Topknot", "Your hair is currently styled like this!");
+				
+				if (target.hairType == GLOBAL.HAIR_TYPE_GOO && target.hairColor != "green") addButton(6, "Dye Hair", DyeHair, target, "Dye Hair", "Use the goo to dye your hair.");
+				else if (target.hairType != GLOBAL.HAIR_TYPE_GOO) addDisabledButton(6, "Dye Hair", "Dye Hair", "The gooball can only dye gooey hair types!");
+				else addDisabledButton(6, "Dye Hair", "Dye Hair", "Your hair’s already been dyed the colour of this ball of goo!");
+				
+				if ((target.skinType == GLOBAL.SKIN_TYPE_GOO || target.hasSkinFlag(GLOBAL.TYPE_GOOEY)) && target.skinTone != "green") addButton(7, "Dye Body", DyeBody, target, "Dye Body", "Use the goo to dye your gooey body.");
+				else if (target.skinTone == "green") addDisabledButton(7, "Dye Body", "Dye Body", "Your body is already the same color as this ball of goo!");
+				else addDisabledButton(7, "Dye Body", "Dye Body", "Eating this without a gooey body would result in one hell of a blockage.");
+				
+				addButton(14, "Back", kGAMECLASS.useItemFunction);
+				
+				return true;
 			}
-			else {
+			else 
+			{
 				kGAMECLASS.output(target.capitalA + target.short + " rubs the goo on their head to no effect.");
+				return false;
 			}
-			return false;
 		}
 	}
 }

--- a/classes/Items/Transformatives/GooBallOrange.as
+++ b/classes/Items/Transformatives/GooBallOrange.as
@@ -30,13 +30,14 @@
 			TooltipManager.addFullName(this.shortName, StringUtil.toTitleCase(this.longName));
 			
 			//Longass shit, not sure what used for yet.
-			this.description = "a orange ball of goo";
+			this.description = "an orange ball of goo";
 			//Displayed on tooltips during mouseovers
 			this.tooltip = "This ball of goo smells pretty acrid, so you probably shouldn't eat it. The ganrael use it to alter their gooey locks. Maybe it'll work on more traditional types of hair too?";
 			
 			TooltipManager.addTooltip(this.shortName, this.tooltip);
 			
 			this.attackVerb = "";
+			addFlag(GLOBAL.NOT_CONSUMED_BY_DEFAULT);
 			
 			//Information
 			this.basePrice = 70;
@@ -52,38 +53,203 @@
 			this.version = this._latestVersion;
 		}
 		
-		protected function rand(max: Number): Number {
- 			return int(Math.random() * max);
- 		}
+		private function GooballUsed(target:Creature):void
+		{
+			target.destroyItemByType(GooBallOrange);
+			
+			clearMenu();
+			addButton(0, "Next", kGAMECLASS.useItemFunction);
+		}
+		
+		private function DoSpikehawk(target:Creature):void
+		{
+			clearOutput();
+			output("You apply the gel to your mohawk and pinch it into four vicious, punk spikes. The devil on your shoulder is going to get a poke in the eye next time you turn your head.");
+			target.hairStyle = "spikehawk";
+			
+			if (target.hairType == GLOBAL.HAIR_TYPE_GOO && target.hairColor != "orange")
+			{
+				output(" The gel’s color also bleeds through, turning the points orange.");
+				target.hairColor = "orange";
+			}
+			
+			GooballUsed(target);
+		}
+		
+		private function DoQuiff(target:Creature):void
+		{
+			clearOutput();
+			output("You slather gel into your " + target.hairDescript(true, true) +" and, when it begins to harden, put it up into a big, tapered point! Your fans will adore it.");
+			target.hairStyle = "quiff";
+			
+			if (target.hairType == GLOBAL.HAIR_TYPE_GOO && target.hairColor != "orange")
+			{
+				output(" The color also swamps your gooey locks, turning them orange.");
+				target.hairColor = "orange";
+			}
+			
+			GooballUsed(target);
+		}
+		
+		private function DoRinglets(target:Creature):void
+		{
+			clearOutput();
+			output("You slather your " + target.hairDescript(true, true) +" one lock at a time and twist it around your fingers. The gel");
+			target.hairStyle = "ringlets";
+			
+			if (target.hairType == GLOBAL.HAIR_TYPE_GOO && target.hairColor != "orange")
+			{
+				output(" bleeds color through your goopy drape and");
+				target.hairColor = "orange";
+			}
+			
+			output(" hardens your ‘do into" + target.hairColor + ", bouncy ringlets. Cute!");
+			
+			GooballUsed(target);
+		}
+		
+		private function DoCurtains(target:Creature):void
+		{
+			clearOutput();
+			output("You smear gel onto your antennae and then stick your bangs to them. The gel hardens, and you can move them to open your hair like drapes. Now you can flash people with your face!");
+			target.hairStyle = "curtains";
+			
+			if (target.hairType == GLOBAL.HAIR_TYPE_GOO) target.hairColor = "orange";
+			else if (target.hairType == GLOBAL.HAIR_TYPE_TENTACLES) output(" Well, you could before, but now it looks theatrical.");
+			
+			GooballUsed(target);
+		}
+		
+		private function DoFingerwave(target:Creature):void
+		{
+			clearOutput();
+			output("You rub the gel into your " + target.hairDescript(true, true) +" and crimp it into waves for a classy, classic look.");
+			target.hairStyle = "fingerwave";
+			
+			if (target.hairType == GLOBAL.HAIR_TYPE_GOO && target.hairColor != "orange")
+			{
+				output(" The gel’s color also spreads, turning your gooey locks orange.");
+				target.hairColor = "orange";
+			}
+			output(" <i>Très chic</i>.");
+			
+			GooballUsed(target);
+		}
+		
+		private function DoTopknot(target:Creature):void
+		{
+			clearOutput();
+			output("You apply the gel to your " + target.hairDescript(true, true) + " and then pin it up in a tight topknot. It’s solid enough to anchor a helmet");
+			target.hairStyle = "topknot";
+			if (target.hairType == GLOBAL.HAIR_TYPE_FEATHERS)
+			{
+				output(", and you even fan the tips of your feathers into a gingko leaf shape");
+			}
+			output("!");
+			
+			if (target.hairType == GLOBAL.HAIR_TYPE_GOO && target.hairColor != "orange")
+			{
+				output(" The ball’s color also swamps your own, changing your hair to orange.");
+				target.hairColor = "orange";
+			}
+			
+			GooballUsed(target);
+		}
+		
+		private function DyeHair(target:Creature):void
+		{
+			clearOutput();
+			output("You carefully work the gel into your " + target.hairDescript(true, false) +", doing your utmost not to disturb your hairstyle in the process. In a matter of seconds your locks begin to soak up the shade of the gel, changing your hair to orange.");
+			target.hairColor = "orange";
+			
+			GooballUsed(target);
+		}
+		
+		private function DyeBody(target:Creature):void
+		{
+			clearOutput();
+			output("You stare down the glob like a horse pill and then throw it in your hatch. It feels like swallowing cotton. By the time it reaches your chest, it’s already begun to leak a cloud of color which radiates all over, making you stiff and slightly numb. <b>When full sensation comes back, your skin is orange!</b>");
+			
+			target.skinTone = "orange";
+			
+			GooballUsed(target);
+		}
 		
 		//METHOD ACTING!
 		override public function useFunction(target:Creature, usingCreature:Creature = null):Boolean
 		{
 			kGAMECLASS.clearOutput();
 			author("Gardeford");
-			if(target is PlayerCharacter) {
-				//pc is human
-				if(target.hairType != GLOBAL.HAIR_TYPE_GOO)
+			if (target is PlayerCharacter) 
+			{
+				output("You consider the blob of ganrael goo, which has formed a slight crust on its surface. If you wanted, you could probably smear it on something to stiffen it... your hair, for example.");
+				if (target.hairType == GLOBAL.HAIR_TYPE_GOO)
 				{
-					output("You rub the ball of goo ");
-					if(target.hasHair()) output("into your [pc.hair]");
-					else output("onto your scalp");
-					output(". You stand for a moment, waiting for something to happen. Eventually you realize that nothing is going to happen, and you've just rubbed a wad of goo all over your head...");
+					output(" It’d probably change your color if you did, since your hair is also goo.");
+					if (target.skinType == GLOBAL.SKIN_TYPE_GOO || target.hasSkinFlag(GLOBAL.FLAG_GOOEY)) output(" For that matter, it’d work on your body, too.");
 				}
-				//pc is goo
-				else
+				else if (target.skinType == GLOBAL.SKIN_TYPE_GOO || target.hasSkinFlag(GLOBAL.FLAG_GOOEY)) output(" It’d probably change the color of your body too, since your skin is gooey.");
+				
+				clearMenu();
+				if (target.hairStyle != "spikehawk")
 				{
-					output("You rub the ball of goo ");
-					if(target.hasHair()) output("into your [pc.hair]");
-					else output("onto your scalp");
-					output(", smiling widely when it's color changes to match the ball's. Using your codex's mirror function, you admire the new color, striking a few cool poses to test it out.");
-					target.hairColor = "orange";
+					if (target.hairStyle == "mohawk") addButton(0, "Spikehawk", DoSpikehawk, target, "Spikey Mohawk", "Shape your mohawk into a spikehawk.");
+					else addDisabledButton(0, "Spikehawk", "Spikey Mohawk", "You don’t have a mohawk to spike.");
 				}
+				else addDisabledButton(0, "Spikehawk", "Spikey Mohawk", "Your hair is currently styled like this!");
+				
+				if (target.hairStyle != "quiff")
+				{
+					if (target.hairLength >= 5) addButton(1, "Quiff", DoQuiff, target, "Quiff", "Shape your hair into a single sleek, tapered point.");
+					else addDisabledButton(1, "Quiff", "Quiff", "Your hair’s too short for this style.");
+				}
+				else addDisabledButton(1, "Quiff", "Quiff", "Your hair is currently styled like this!");
+				
+				if (target.hairStyle != "ringlets")
+				{
+					if (target.hairLength >= 10) addButton(2, "Ringlets", DoRinglets, target, "Ringlets", "Shape your hair into helical loops.");
+					else addDisabledButton(2, "Ringlets", "Ringlets", "Your hair’s too short for this style.");
+				}
+				else addDisabledButton(2, "Ringlets", "Ringlets", "Your hair is currently styled like this!");
+				
+				if (target.hairStyle != "curtains")
+				{
+					if (target.hairLength >= 10 && target.hasAntennae()) addButton(3, "Curtains", DoCurtains, target, "Curtains", "Glue your bangs to your antennae and make curtains you can wave around.");
+					else if (target.hairLength < 10) addDisabledButton(3, "Curtains", "Curtains", "You don’t have long enough hair.");
+					else addDisabledButton(3, "Curtains", "Curtains", "You don’t have antennae.");
+				}
+				else addDisabledButton(3, "Curtains", "Curtains", "Your hair is currently styled like this!");
+				
+				if (target.hairStyle != "fingerwave")
+				{
+					addButton(4, "Fingerwave", DoFingerwave, target, "Fingerwave", "Shape your hair into a wavy, close bob.");
+				}
+				else addDisabledButton(4, "Fingerwave", "Fingerwave", "Your hair is currently styled like this!");
+				
+				if (target.hairStyle != "topknot")
+				{
+					if (target.hairLength <= 6) addButton(5, "Topknot", DoTopknot, target, "Topknot", "Put your hair up in an ironclad topknot.");
+					else addDisabledButton(5, "Topknot", "Topknot", "You have too much hair for this style.");
+				}
+				else addDisabledButton(5, "Topknot", "Topknot", "Your hair is currently styled like this!");
+				
+				if (target.hairType == GLOBAL.HAIR_TYPE_GOO && target.hairColor != "orange") addButton(6, "Dye Hair", DyeHair, target, "Dye Hair", "Use the goo to dye your hair.");
+				else if (target.hairType != GLOBAL.HAIR_TYPE_GOO) addDisabledButton(6, "Dye Hair", "Dye Hair", "The gooball can only dye gooey hair types!");
+				else addDisabledButton(6, "Dye Hair", "Dye Hair", "Your hair’s already been dyed the colour of this ball of goo!");
+				
+				if ((target.skinType == GLOBAL.SKIN_TYPE_GOO || target.hasSkinFlag(GLOBAL.TYPE_GOOEY)) && target.skinTone != "orange") addButton(7, "Dye Body", DyeBody, target, "Dye Body", "Use the goo to dye your gooey body.");
+				else if (target.skinTone == "orange") addDisabledButton(7, "Dye Body", "Dye Body", "Your body is already the same color as this ball of goo!");
+				else addDisabledButton(7, "Dye Body", "Dye Body", "Eating this without a gooey body would result in one hell of a blockage.");
+				
+				addButton(14, "Back", kGAMECLASS.useItemFunction);
+				
+				return true;
 			}
-			else {
+			else 
+			{
 				kGAMECLASS.output(target.capitalA + target.short + " rubs the goo on their head to no effect.");
+				return false;
 			}
-			return false;
 		}
 	}
 }

--- a/classes/Items/Transformatives/GooBallPink.as
+++ b/classes/Items/Transformatives/GooBallPink.as
@@ -37,6 +37,7 @@
 			TooltipManager.addTooltip(this.shortName, this.tooltip);
 			
 			this.attackVerb = "";
+			addFlag(GLOBAL.NOT_CONSUMED_BY_DEFAULT);
 			
 			//Information
 			this.basePrice = 70;
@@ -52,38 +53,203 @@
 			this.version = this._latestVersion;
 		}
 		
-		protected function rand(max: Number): Number {
- 			return int(Math.random() * max);
- 		}
+		private function GooballUsed(target:Creature):void
+		{
+			target.destroyItemByType(GooBallPink);
+			
+			clearMenu();
+			addButton(0, "Next", kGAMECLASS.useItemFunction);
+		}
+		
+		private function DoSpikehawk(target:Creature):void
+		{
+			clearOutput();
+			output("You apply the gel to your mohawk and pinch it into four vicious, punk spikes. The devil on your shoulder is going to get a poke in the eye next time you turn your head.");
+			target.hairStyle = "spikehawk";
+			
+			if (target.hairType == GLOBAL.HAIR_TYPE_GOO && target.hairColor != "pink")
+			{
+				output(" The gel’s color also bleeds through, turning the points pink.");
+				target.hairColor = "pink";
+			}
+			
+			GooballUsed(target);
+		}
+		
+		private function DoQuiff(target:Creature):void
+		{
+			clearOutput();
+			output("You slather gel into your " + target.hairDescript(true, true) +" and, when it begins to harden, put it up into a big, tapered point! Your fans will adore it.");
+			target.hairStyle = "quiff";
+			
+			if (target.hairType == GLOBAL.HAIR_TYPE_GOO && target.hairColor != "pink")
+			{
+				output(" The color also swamps your gooey locks, turning them pink.");
+				target.hairColor = "pink";
+			}
+			
+			GooballUsed(target);
+		}
+		
+		private function DoRinglets(target:Creature):void
+		{
+			clearOutput();
+			output("You slather your " + target.hairDescript(true, true) +" one lock at a time and twist it around your fingers. The gel");
+			target.hairStyle = "ringlets";
+			
+			if (target.hairType == GLOBAL.HAIR_TYPE_GOO && target.hairColor != "pink")
+			{
+				output(" bleeds color through your goopy drape and");
+				target.hairColor = "pink";
+			}
+			
+			output(" hardens your ‘do into" + target.hairColor + ", bouncy ringlets. Cute!");
+			
+			GooballUsed(target);
+		}
+		
+		private function DoCurtains(target:Creature):void
+		{
+			clearOutput();
+			output("You smear gel onto your antennae and then stick your bangs to them. The gel hardens, and you can move them to open your hair like drapes. Now you can flash people with your face!");
+			target.hairStyle = "curtains";
+			
+			if (target.hairType == GLOBAL.HAIR_TYPE_GOO) target.hairColor = "pink";
+			else if (target.hairType == GLOBAL.HAIR_TYPE_TENTACLES) output(" Well, you could before, but now it looks theatrical.");
+			
+			GooballUsed(target);
+		}
+		
+		private function DoFingerwave(target:Creature):void
+		{
+			clearOutput();
+			output("You rub the gel into your " + target.hairDescript(true, true) +" and crimp it into waves for a classy, classic look.");
+			target.hairStyle = "fingerwave";
+			
+			if (target.hairType == GLOBAL.HAIR_TYPE_GOO && target.hairColor != "pink")
+			{
+				output(" The gel’s color also spreads, turning your gooey locks pink.");
+				target.hairColor = "pink";
+			}
+			output(" <i>Très chic</i>.");
+			
+			GooballUsed(target);
+		}
+		
+		private function DoTopknot(target:Creature):void
+		{
+			clearOutput();
+			output("You apply the gel to your " + target.hairDescript(true, true) + " and then pin it up in a tight topknot. It’s solid enough to anchor a helmet");
+			target.hairStyle = "topknot";
+			if (target.hairType == GLOBAL.HAIR_TYPE_FEATHERS)
+			{
+				output(", and you even fan the tips of your feathers into a gingko leaf shape");
+			}
+			output("!");
+			
+			if (target.hairType == GLOBAL.HAIR_TYPE_GOO && target.hairColor != "pink")
+			{
+				output(" The ball’s color also swamps your own, changing your hair to pink.");
+				target.hairColor = "pink";
+			}
+			
+			GooballUsed(target);
+		}
+		
+		private function DyeHair(target:Creature):void
+		{
+			clearOutput();
+			output("You carefully work the gel into your " + target.hairDescript(true, false) +", doing your utmost not to disturb your hairstyle in the process. In a matter of seconds your locks begin to soak up the shade of the gel, changing your hair to pink.");
+			target.hairColor = "pink";
+			
+			GooballUsed(target);
+		}
+		
+		private function DyeBody(target:Creature):void
+		{
+			clearOutput();
+			output("You stare down the glob like a horse pill and then throw it in your hatch. It feels like swallowing cotton. By the time it reaches your chest, it’s already begun to leak a cloud of color which radiates all over, making you stiff and slightly numb. <b>When full sensation comes back, your skin is pink!</b>");
+			
+			target.skinTone = "pink";
+			
+			GooballUsed(target);
+		}
 		
 		//METHOD ACTING!
 		override public function useFunction(target:Creature, usingCreature:Creature = null):Boolean
 		{
 			kGAMECLASS.clearOutput();
 			author("Gardeford");
-			if(target is PlayerCharacter) {
-				//pc is human
-				if(target.hairType != GLOBAL.HAIR_TYPE_GOO)
+			if (target is PlayerCharacter) 
+			{
+				output("You consider the blob of ganrael goo, which has formed a slight crust on its surface. If you wanted, you could probably smear it on something to stiffen it... your hair, for example.");
+				if (target.hairType == GLOBAL.HAIR_TYPE_GOO)
 				{
-					output("You rub the ball of goo ");
-					if(target.hasHair()) output("into your [pc.hair]");
-					else output("onto your scalp");
-					output(". You stand for a moment, waiting for something to happen. Eventually you realize that nothing is going to happen, and you've just rubbed a wad of goo all over your head...");
+					output(" It’d probably change your color if you did, since your hair is also goo.");
+					if (target.skinType == GLOBAL.SKIN_TYPE_GOO || target.hasSkinFlag(GLOBAL.FLAG_GOOEY)) output(" For that matter, it’d work on your body, too.");
 				}
-				//pc is goo
-				else
+				else if (target.skinType == GLOBAL.SKIN_TYPE_GOO || target.hasSkinFlag(GLOBAL.FLAG_GOOEY)) output(" It’d probably change the color of your body too, since your skin is gooey.");
+				
+				clearMenu();
+				if (target.hairStyle != "spikehawk")
 				{
-					output("You rub the ball of goo ");
-					if(target.hasHair()) output("into your [pc.hair]");
-					else output("onto your scalp");
-					output(", smiling widely when it's color changes to match the ball's. Using your codex's mirror function, you admire the new color, striking a few cool poses to test it out.");
-					target.hairColor = "pink";
+					if (target.hairStyle == "mohawk") addButton(0, "Spikehawk", DoSpikehawk, target, "Spikey Mohawk", "Shape your mohawk into a spikehawk.");
+					else addDisabledButton(0, "Spikehawk", "Spikey Mohawk", "You don’t have a mohawk to spike.");
 				}
+				else addDisabledButton(0, "Spikehawk", "Spikey Mohawk", "Your hair is currently styled like this!");
+				
+				if (target.hairStyle != "quiff")
+				{
+					if (target.hairLength >= 5) addButton(1, "Quiff", DoQuiff, target, "Quiff", "Shape your hair into a single sleek, tapered point.");
+					else addDisabledButton(1, "Quiff", "Quiff", "Your hair’s too short for this style.");
+				}
+				else addDisabledButton(1, "Quiff", "Quiff", "Your hair is currently styled like this!");
+				
+				if (target.hairStyle != "ringlets")
+				{
+					if (target.hairLength >= 10) addButton(2, "Ringlets", DoRinglets, target, "Ringlets", "Shape your hair into helical loops.");
+					else addDisabledButton(2, "Ringlets", "Ringlets", "Your hair’s too short for this style.");
+				}
+				else addDisabledButton(2, "Ringlets", "Ringlets", "Your hair is currently styled like this!");
+				
+				if (target.hairStyle != "curtains")
+				{
+					if (target.hairLength >= 10 && target.hasAntennae()) addButton(3, "Curtains", DoCurtains, target, "Curtains", "Glue your bangs to your antennae and make curtains you can wave around.");
+					else if (target.hairLength < 10) addDisabledButton(3, "Curtains", "Curtains", "You don’t have long enough hair.");
+					else addDisabledButton(3, "Curtains", "Curtains", "You don’t have antennae.");
+				}
+				else addDisabledButton(3, "Curtains", "Curtains", "Your hair is currently styled like this!");
+				
+				if (target.hairStyle != "fingerwave")
+				{
+					addButton(4, "Fingerwave", DoFingerwave, target, "Fingerwave", "Shape your hair into a wavy, close bob.");
+				}
+				else addDisabledButton(4, "Fingerwave", "Fingerwave", "Your hair is currently styled like this!");
+				
+				if (target.hairStyle != "topknot")
+				{
+					if (target.hairLength <= 6) addButton(5, "Topknot", DoTopknot, target, "Topknot", "Put your hair up in an ironclad topknot.");
+					else addDisabledButton(5, "Topknot", "Topknot", "You have too much hair for this style.");
+				}
+				else addDisabledButton(5, "Topknot", "Topknot", "Your hair is currently styled like this!");
+				
+				if (target.hairType == GLOBAL.HAIR_TYPE_GOO && target.hairColor != "pink") addButton(6, "Dye Hair", DyeHair, target, "Dye Hair", "Use the goo to dye your hair.");
+				else if (target.hairType != GLOBAL.HAIR_TYPE_GOO) addDisabledButton(6, "Dye Hair", "Dye Hair", "The gooball can only dye gooey hair types!");
+				else addDisabledButton(6, "Dye Hair", "Dye Hair", "Your hair’s already been dyed the colour of this ball of goo!");
+				
+				if ((target.skinType == GLOBAL.SKIN_TYPE_GOO || target.hasSkinFlag(GLOBAL.TYPE_GOOEY)) && target.skinTone != "pink") addButton(7, "Dye Body", DyeBody, target, "Dye Body", "Use the goo to dye your gooey body.");
+				else if (target.skinTone == "pink") addDisabledButton(7, "Dye Body", "Dye Body", "Your body is already the same color as this ball of goo!");
+				else addDisabledButton(7, "Dye Body", "Dye Body", "Eating this without a gooey body would result in one hell of a blockage.");
+				
+				addButton(14, "Back", kGAMECLASS.useItemFunction);
+				
+				return true;
 			}
-			else {
+			else 
+			{
 				kGAMECLASS.output(target.capitalA + target.short + " rubs the goo on their head to no effect.");
+				return false;
 			}
-			return false;
 		}
 	}
 }

--- a/classes/Items/Transformatives/GooBallPurple.as
+++ b/classes/Items/Transformatives/GooBallPurple.as
@@ -37,6 +37,7 @@
 			TooltipManager.addTooltip(this.shortName, this.tooltip);
 			
 			this.attackVerb = "";
+			addFlag(GLOBAL.NOT_CONSUMED_BY_DEFAULT);
 			
 			//Information
 			this.basePrice = 150;
@@ -52,38 +53,203 @@
 			this.version = this._latestVersion;
 		}
 		
-		protected function rand(max: Number): Number {
- 			return int(Math.random() * max);
- 		}
+		private function GooballUsed(target:Creature):void
+		{
+			target.destroyItemByType(GooBallPurple);
+			
+			clearMenu();
+			addButton(0, "Next", kGAMECLASS.useItemFunction);
+		}
+		
+		private function DoSpikehawk(target:Creature):void
+		{
+			clearOutput();
+			output("You apply the gel to your mohawk and pinch it into four vicious, punk spikes. The devil on your shoulder is going to get a poke in the eye next time you turn your head.");
+			target.hairStyle = "spikehawk";
+			
+			if (target.hairType == GLOBAL.HAIR_TYPE_GOO && target.hairColor != "purple")
+			{
+				output(" The gel’s color also bleeds through, turning the points purple.");
+				target.hairColor = "purple";
+			}
+			
+			GooballUsed(target);
+		}
+		
+		private function DoQuiff(target:Creature):void
+		{
+			clearOutput();
+			output("You slather gel into your " + target.hairDescript(true, true) +" and, when it begins to harden, put it up into a big, tapered point! Your fans will adore it.");
+			target.hairStyle = "quiff";
+			
+			if (target.hairType == GLOBAL.HAIR_TYPE_GOO && target.hairColor != "purple")
+			{
+				output(" The color also swamps your gooey locks, turning them purple.");
+				target.hairColor = "purple";
+			}
+			
+			GooballUsed(target);
+		}
+		
+		private function DoRinglets(target:Creature):void
+		{
+			clearOutput();
+			output("You slather your " + target.hairDescript(true, true) +" one lock at a time and twist it around your fingers. The gel");
+			target.hairStyle = "ringlets";
+			
+			if (target.hairType == GLOBAL.HAIR_TYPE_GOO && target.hairColor != "purple")
+			{
+				output(" bleeds color through your goopy drape and");
+				target.hairColor = "purple";
+			}
+			
+			output(" hardens your ‘do into" + target.hairColor + ", bouncy ringlets. Cute!");
+			
+			GooballUsed(target);
+		}
+		
+		private function DoCurtains(target:Creature):void
+		{
+			clearOutput();
+			output("You smear gel onto your antennae and then stick your bangs to them. The gel hardens, and you can move them to open your hair like drapes. Now you can flash people with your face!");
+			target.hairStyle = "curtains";
+			
+			if (target.hairType == GLOBAL.HAIR_TYPE_GOO) target.hairColor = "purple";
+			else if (target.hairType == GLOBAL.HAIR_TYPE_TENTACLES) output(" Well, you could before, but now it looks theatrical.");
+			
+			GooballUsed(target);
+		}
+		
+		private function DoFingerwave(target:Creature):void
+		{
+			clearOutput();
+			output("You rub the gel into your " + target.hairDescript(true, true) +" and crimp it into waves for a classy, classic look.");
+			target.hairStyle = "fingerwave";
+			
+			if (target.hairType == GLOBAL.HAIR_TYPE_GOO && target.hairColor != "purple")
+			{
+				output(" The gel’s color also spreads, turning your gooey locks purple.");
+				target.hairColor = "purple";
+			}
+			output(" <i>Très chic</i>.");
+			
+			GooballUsed(target);
+		}
+		
+		private function DoTopknot(target:Creature):void
+		{
+			clearOutput();
+			output("You apply the gel to your " + target.hairDescript(true, true) + " and then pin it up in a tight topknot. It’s solid enough to anchor a helmet");
+			target.hairStyle = "topknot";
+			if (target.hairType == GLOBAL.HAIR_TYPE_FEATHERS)
+			{
+				output(", and you even fan the tips of your feathers into a gingko leaf shape");
+			}
+			output("!");
+			
+			if (target.hairType == GLOBAL.HAIR_TYPE_GOO && target.hairColor != "purple")
+			{
+				output(" The ball’s color also swamps your own, changing your hair to purple.");
+				target.hairColor = "purple";
+			}
+			
+			GooballUsed(target);
+		}
+		
+		private function DyeHair(target:Creature):void
+		{
+			clearOutput();
+			output("You carefully work the gel into your " + target.hairDescript(true, false) +", doing your utmost not to disturb your hairstyle in the process. In a matter of seconds your locks begin to soak up the shade of the gel, changing your hair to purple.");
+			target.hairColor = "purple";
+			
+			GooballUsed(target);
+		}
+		
+		private function DyeBody(target:Creature):void
+		{
+			clearOutput();
+			output("You stare down the glob like a horse pill and then throw it in your hatch. It feels like swallowing cotton. By the time it reaches your chest, it’s already begun to leak a cloud of color which radiates all over, making you stiff and slightly numb. <b>When full sensation comes back, your skin is purple!</b>");
+			
+			target.skinTone = "purple";
+			
+			GooballUsed(target);
+		}
 		
 		//METHOD ACTING!
 		override public function useFunction(target:Creature, usingCreature:Creature = null):Boolean
 		{
 			kGAMECLASS.clearOutput();
 			author("Gardeford");
-			if(target is PlayerCharacter) {
-				//pc is human
-				if(target.hairType != GLOBAL.HAIR_TYPE_GOO)
+			if (target is PlayerCharacter) 
+			{
+				output("You consider the blob of ganrael goo, which has formed a slight crust on its surface. If you wanted, you could probably smear it on something to stiffen it... your hair, for example.");
+				if (target.hairType == GLOBAL.HAIR_TYPE_GOO)
 				{
-					output("You rub the ball of goo ");
-					if(target.hasHair()) output("into your [pc.hair]");
-					else output("onto your scalp");
-					output(". You stand for a moment, waiting for something to happen. Eventually you realize that nothing is going to happen, and you've just rubbed a wad of goo all over your head...");
+					output(" It’d probably change your color if you did, since your hair is also goo.");
+					if (target.skinType == GLOBAL.SKIN_TYPE_GOO || target.hasSkinFlag(GLOBAL.FLAG_GOOEY)) output(" For that matter, it’d work on your body, too.");
 				}
-				//pc is goo
-				else
+				else if (target.skinType == GLOBAL.SKIN_TYPE_GOO || target.hasSkinFlag(GLOBAL.FLAG_GOOEY)) output(" It’d probably change the color of your body too, since your skin is gooey.");
+				
+				clearMenu();
+				if (target.hairStyle != "spikehawk")
 				{
-					output("You rub the ball of goo ");
-					if(target.hasHair()) output("into your [pc.hair]");
-					else output("onto your scalp");
-					output(", smiling widely when it's color changes to match the ball's. Using your codex's mirror function, you admire the new color, striking a few cool poses to test it out.");
-					target.hairColor = "purple";
+					if (target.hairStyle == "mohawk") addButton(0, "Spikehawk", DoSpikehawk, target, "Spikey Mohawk", "Shape your mohawk into a spikehawk.");
+					else addDisabledButton(0, "Spikehawk", "Spikey Mohawk", "You don’t have a mohawk to spike.");
 				}
+				else addDisabledButton(0, "Spikehawk", "Spikey Mohawk", "Your hair is currently styled like this!");
+				
+				if (target.hairStyle != "quiff")
+				{
+					if (target.hairLength >= 5) addButton(1, "Quiff", DoQuiff, target, "Quiff", "Shape your hair into a single sleek, tapered point.");
+					else addDisabledButton(1, "Quiff", "Quiff", "Your hair’s too short for this style.");
+				}
+				else addDisabledButton(1, "Quiff", "Quiff", "Your hair is currently styled like this!");
+				
+				if (target.hairStyle != "ringlets")
+				{
+					if (target.hairLength >= 10) addButton(2, "Ringlets", DoRinglets, target, "Ringlets", "Shape your hair into helical loops.");
+					else addDisabledButton(2, "Ringlets", "Ringlets", "Your hair’s too short for this style.");
+				}
+				else addDisabledButton(2, "Ringlets", "Ringlets", "Your hair is currently styled like this!");
+				
+				if (target.hairStyle != "curtains")
+				{
+					if (target.hairLength >= 10 && target.hasAntennae()) addButton(3, "Curtains", DoCurtains, target, "Curtains", "Glue your bangs to your antennae and make curtains you can wave around.");
+					else if (target.hairLength < 10) addDisabledButton(3, "Curtains", "Curtains", "You don’t have long enough hair.");
+					else addDisabledButton(3, "Curtains", "Curtains", "You don’t have antennae.");
+				}
+				else addDisabledButton(3, "Curtains", "Curtains", "Your hair is currently styled like this!");
+				
+				if (target.hairStyle != "fingerwave")
+				{
+					addButton(4, "Fingerwave", DoFingerwave, target, "Fingerwave", "Shape your hair into a wavy, close bob.");
+				}
+				else addDisabledButton(4, "Fingerwave", "Fingerwave", "Your hair is currently styled like this!");
+				
+				if (target.hairStyle != "topknot")
+				{
+					if (target.hairLength <= 6) addButton(5, "Topknot", DoTopknot, target, "Topknot", "Put your hair up in an ironclad topknot.");
+					else addDisabledButton(5, "Topknot", "Topknot", "You have too much hair for this style.");
+				}
+				else addDisabledButton(5, "Topknot", "Topknot", "Your hair is currently styled like this!");
+				
+				if (target.hairType == GLOBAL.HAIR_TYPE_GOO && target.hairColor != "purple") addButton(6, "Dye Hair", DyeHair, target, "Dye Hair", "Use the goo to dye your hair.");
+				else if (target.hairType != GLOBAL.HAIR_TYPE_GOO) addDisabledButton(6, "Dye Hair", "Dye Hair", "The gooball can only dye gooey hair types!");
+				else addDisabledButton(6, "Dye Hair", "Dye Hair", "Your hair’s already been dyed the colour of this ball of goo!");
+				
+				if ((target.skinType == GLOBAL.SKIN_TYPE_GOO || target.hasSkinFlag(GLOBAL.TYPE_GOOEY)) && target.skinTone != "purple") addButton(7, "Dye Body", DyeBody, target, "Dye Body", "Use the goo to dye your gooey body.");
+				else if (target.skinTone == "purple") addDisabledButton(7, "Dye Body", "Dye Body", "Your body is already the same color as this ball of goo!");
+				else addDisabledButton(7, "Dye Body", "Dye Body", "Eating this without a gooey body would result in one hell of a blockage.");
+				
+				addButton(14, "Back", kGAMECLASS.useItemFunction);
+				
+				return true;
 			}
-			else {
+			else 
+			{
 				kGAMECLASS.output(target.capitalA + target.short + " rubs the goo on their head to no effect.");
+				return false;
 			}
-			return false;
 		}
 	}
 }

--- a/classes/Items/Transformatives/GooBallRed.as
+++ b/classes/Items/Transformatives/GooBallRed.as
@@ -37,6 +37,7 @@
 			TooltipManager.addTooltip(this.shortName, this.tooltip);
 			
 			this.attackVerb = "";
+			addFlag(GLOBAL.NOT_CONSUMED_BY_DEFAULT);
 			
 			//Information
 			this.basePrice = 70;
@@ -52,38 +53,203 @@
 			this.version = this._latestVersion;
 		}
 		
-		protected function rand(max: Number): Number {
- 			return int(Math.random() * max);
- 		}
+		private function GooballUsed(target:Creature):void
+		{
+			target.destroyItemByType(GooBallRed);
+			
+			clearMenu();
+			addButton(0, "Next", kGAMECLASS.useItemFunction);
+		}
+		
+		private function DoSpikehawk(target:Creature):void
+		{
+			clearOutput();
+			output("You apply the gel to your mohawk and pinch it into four vicious, punk spikes. The devil on your shoulder is going to get a poke in the eye next time you turn your head.");
+			target.hairStyle = "spikehawk";
+			
+			if (target.hairType == GLOBAL.HAIR_TYPE_GOO && target.hairColor != "red")
+			{
+				output(" The gel’s color also bleeds through, turning the points red.");
+				target.hairColor = "red";
+			}
+			
+			GooballUsed(target);
+		}
+		
+		private function DoQuiff(target:Creature):void
+		{
+			clearOutput();
+			output("You slather gel into your " + target.hairDescript(true, true) +" and, when it begins to harden, put it up into a big, tapered point! Your fans will adore it.");
+			target.hairStyle = "quiff";
+			
+			if (target.hairType == GLOBAL.HAIR_TYPE_GOO && target.hairColor != "red")
+			{
+				output(" The color also swamps your gooey locks, turning them red.");
+				target.hairColor = "red";
+			}
+			
+			GooballUsed(target);
+		}
+		
+		private function DoRinglets(target:Creature):void
+		{
+			clearOutput();
+			output("You slather your " + target.hairDescript(true, true) +" one lock at a time and twist it around your fingers. The gel");
+			target.hairStyle = "ringlets";
+			
+			if (target.hairType == GLOBAL.HAIR_TYPE_GOO && target.hairColor != "red")
+			{
+				output(" bleeds color through your goopy drape and");
+				target.hairColor = "red";
+			}
+			
+			output(" hardens your ‘do into" + target.hairColor + ", bouncy ringlets. Cute!");
+			
+			GooballUsed(target);
+		}
+		
+		private function DoCurtains(target:Creature):void
+		{
+			clearOutput();
+			output("You smear gel onto your antennae and then stick your bangs to them. The gel hardens, and you can move them to open your hair like drapes. Now you can flash people with your face!");
+			target.hairStyle = "curtains";
+			
+			if (target.hairType == GLOBAL.HAIR_TYPE_GOO) target.hairColor = "red";
+			else if (target.hairType == GLOBAL.HAIR_TYPE_TENTACLES) output(" Well, you could before, but now it looks theatrical.");
+			
+			GooballUsed(target);
+		}
+		
+		private function DoFingerwave(target:Creature):void
+		{
+			clearOutput();
+			output("You rub the gel into your " + target.hairDescript(true, true) +" and crimp it into waves for a classy, classic look.");
+			target.hairStyle = "fingerwave";
+			
+			if (target.hairType == GLOBAL.HAIR_TYPE_GOO && target.hairColor != "red")
+			{
+				output(" The gel’s color also spreads, turning your gooey locks red.");
+				target.hairColor = "red";
+			}
+			output(" <i>Très chic</i>.");
+			
+			GooballUsed(target);
+		}
+		
+		private function DoTopknot(target:Creature):void
+		{
+			clearOutput();
+			output("You apply the gel to your " + target.hairDescript(true, true) + " and then pin it up in a tight topknot. It’s solid enough to anchor a helmet");
+			target.hairStyle = "topknot";
+			if (target.hairType == GLOBAL.HAIR_TYPE_FEATHERS)
+			{
+				output(", and you even fan the tips of your feathers into a gingko leaf shape");
+			}
+			output("!");
+			
+			if (target.hairType == GLOBAL.HAIR_TYPE_GOO && target.hairColor != "red")
+			{
+				output(" The ball’s color also swamps your own, changing your hair to red.");
+				target.hairColor = "red";
+			}
+			
+			GooballUsed(target);
+		}
+		
+		private function DyeHair(target:Creature):void
+		{
+			clearOutput();
+			output("You carefully work the gel into your " + target.hairDescript(true, false) +", doing your utmost not to disturb your hairstyle in the process. In a matter of seconds your locks begin to soak up the shade of the gel, changing your hair to red.");
+			target.hairColor = "red";
+			
+			GooballUsed(target);
+		}
+		
+		private function DyeBody(target:Creature):void
+		{
+			clearOutput();
+			output("You stare down the glob like a horse pill and then throw it in your hatch. It feels like swallowing cotton. By the time it reaches your chest, it’s already begun to leak a cloud of color which radiates all over, making you stiff and slightly numb. <b>When full sensation comes back, your skin is red!</b>");
+			
+			target.skinTone = "red";
+			
+			GooballUsed(target);
+		}
 		
 		//METHOD ACTING!
 		override public function useFunction(target:Creature, usingCreature:Creature = null):Boolean
 		{
 			kGAMECLASS.clearOutput();
 			author("Gardeford");
-			if(target is PlayerCharacter) {
-				//pc is human
-				if(target.hairType != GLOBAL.HAIR_TYPE_GOO)
+			if (target is PlayerCharacter) 
+			{
+				output("You consider the blob of ganrael goo, which has formed a slight crust on its surface. If you wanted, you could probably smear it on something to stiffen it... your hair, for example.");
+				if (target.hairType == GLOBAL.HAIR_TYPE_GOO)
 				{
-					output("You rub the ball of goo ");
-					if(target.hasHair()) output("into your [pc.hair]");
-					else output("onto your scalp");
-					output(". You stand for a moment, waiting for something to happen. Eventually you realize that nothing is going to happen, and you've just rubbed a wad of goo all over your head...");
+					output(" It’d probably change your color if you did, since your hair is also goo.");
+					if (target.skinType == GLOBAL.SKIN_TYPE_GOO || target.hasSkinFlag(GLOBAL.FLAG_GOOEY)) output(" For that matter, it’d work on your body, too.");
 				}
-				//pc is goo
-				else
+				else if (target.skinType == GLOBAL.SKIN_TYPE_GOO || target.hasSkinFlag(GLOBAL.FLAG_GOOEY)) output(" It’d probably change the color of your body too, since your skin is gooey.");
+				
+				clearMenu();
+				if (target.hairStyle != "spikehawk")
 				{
-					output("You rub the ball of goo ");
-					if(target.hasHair()) output("into your [pc.hair]");
-					else output("onto your scalp");
-					output(", smiling widely when it's color changes to match the ball's. Using your codex's mirror function, you admire the new color, striking a few cool poses to test it out.");
-					target.hairColor = "red";
+					if (target.hairStyle == "mohawk") addButton(0, "Spikehawk", DoSpikehawk, target, "Spikey Mohawk", "Shape your mohawk into a spikehawk.");
+					else addDisabledButton(0, "Spikehawk", "Spikey Mohawk", "You don’t have a mohawk to spike.");
 				}
+				else addDisabledButton(0, "Spikehawk", "Spikey Mohawk", "Your hair is currently styled like this!");
+				
+				if (target.hairStyle != "quiff")
+				{
+					if (target.hairLength >= 5) addButton(1, "Quiff", DoQuiff, target, "Quiff", "Shape your hair into a single sleek, tapered point.");
+					else addDisabledButton(1, "Quiff", "Quiff", "Your hair’s too short for this style.");
+				}
+				else addDisabledButton(1, "Quiff", "Quiff", "Your hair is currently styled like this!");
+				
+				if (target.hairStyle != "ringlets")
+				{
+					if (target.hairLength >= 10) addButton(2, "Ringlets", DoRinglets, target, "Ringlets", "Shape your hair into helical loops.");
+					else addDisabledButton(2, "Ringlets", "Ringlets", "Your hair’s too short for this style.");
+				}
+				else addDisabledButton(2, "Ringlets", "Ringlets", "Your hair is currently styled like this!");
+				
+				if (target.hairStyle != "curtains")
+				{
+					if (target.hairLength >= 10 && target.hasAntennae()) addButton(3, "Curtains", DoCurtains, target, "Curtains", "Glue your bangs to your antennae and make curtains you can wave around.");
+					else if (target.hairLength < 10) addDisabledButton(3, "Curtains", "Curtains", "You don’t have long enough hair.");
+					else addDisabledButton(3, "Curtains", "Curtains", "You don’t have antennae.");
+				}
+				else addDisabledButton(3, "Curtains", "Curtains", "Your hair is currently styled like this!");
+				
+				if (target.hairStyle != "fingerwave")
+				{
+					addButton(4, "Fingerwave", DoFingerwave, target, "Fingerwave", "Shape your hair into a wavy, close bob.");
+				}
+				else addDisabledButton(4, "Fingerwave", "Fingerwave", "Your hair is currently styled like this!");
+				
+				if (target.hairStyle != "topknot")
+				{
+					if (target.hairLength <= 6) addButton(5, "Topknot", DoTopknot, target, "Topknot", "Put your hair up in an ironclad topknot.");
+					else addDisabledButton(5, "Topknot", "Topknot", "You have too much hair for this style.");
+				}
+				else addDisabledButton(5, "Topknot", "Topknot", "Your hair is currently styled like this!");
+				
+				if (target.hairType == GLOBAL.HAIR_TYPE_GOO && target.hairColor != "red") addButton(6, "Dye Hair", DyeHair, target, "Dye Hair", "Use the goo to dye your hair.");
+				else if (target.hairType != GLOBAL.HAIR_TYPE_GOO) addDisabledButton(6, "Dye Hair", "Dye Hair", "The gooball can only dye gooey hair types!");
+				else addDisabledButton(6, "Dye Hair", "Dye Hair", "Your hair’s already been dyed the colour of this ball of goo!");
+				
+				if ((target.skinType == GLOBAL.SKIN_TYPE_GOO || target.hasSkinFlag(GLOBAL.TYPE_GOOEY)) && target.skinTone != "red") addButton(7, "Dye Body", DyeBody, target, "Dye Body", "Use the goo to dye your gooey body.");
+				else if (target.skinTone == "red") addDisabledButton(7, "Dye Body", "Dye Body", "Your body is already the same color as this ball of goo!");
+				else addDisabledButton(7, "Dye Body", "Dye Body", "Eating this without a gooey body would result in one hell of a blockage.");
+				
+				addButton(14, "Back", kGAMECLASS.useItemFunction);
+				
+				return true;
 			}
-			else {
+			else 
+			{
 				kGAMECLASS.output(target.capitalA + target.short + " rubs the goo on their head to no effect.");
+				return false;
 			}
-			return false;
 		}
 	}
 }

--- a/classes/Items/Transformatives/GooBallYellow.as
+++ b/classes/Items/Transformatives/GooBallYellow.as
@@ -11,11 +11,10 @@
 	import classes.Util.InCollection;
 	import classes.Util.RandomInCollection;
 	
-	public class GooBallBlue extends ItemSlotClass
+	public class GooBallYellow extends ItemSlotClass
 	{
-		
 		//constructor
-		public function GooBallBlue()
+		public function GooBallYellow()
 		{
 			this._latestVersion = 1;
 			
@@ -23,16 +22,16 @@
 			this.stackSize = 10;
 			this.type = GLOBAL.PILL;
 			//Used on inventory buttons
-			this.shortName = "BlueGB";
+			this.shortName = "Yellow GB";
 			//Regular name
-			this.longName = "blue ball of goo";
+			this.longName = "yellow ball of goo";
 			
 			TooltipManager.addFullName(this.shortName, StringUtil.toTitleCase(this.longName));
 			
 			//Longass shit, not sure what used for yet.
-			this.description = "a blue ball of goo";
+			this.description = "a yellow ball of goo";
 			//Displayed on tooltips during mouseovers
-			this.tooltip = "This ball of goo smells pretty acrid, so you probably shouldn't eat it. The ganrael use it to alter their gooey locks. Maybe it'll work on more traditional types of hair too?";
+			this.tooltip = "This ball of leftover ganrael gloop has formed a little crust all on its own. It doesn’t have much stiffening power remaining but it could hold something light in place, like hair.";
 			
 			TooltipManager.addTooltip(this.shortName, this.tooltip);
 			
@@ -55,7 +54,7 @@
 		
 		private function GooballUsed(target:Creature):void
 		{
-			target.destroyItemByType(GooBallBlue);
+			target.destroyItemByType(GooBallYellow);
 			
 			clearMenu();
 			addButton(0, "Next", kGAMECLASS.useItemFunction);
@@ -67,10 +66,10 @@
 			output("You apply the gel to your mohawk and pinch it into four vicious, punk spikes. The devil on your shoulder is going to get a poke in the eye next time you turn your head.");
 			target.hairStyle = "spikehawk";
 			
-			if (target.hairType == GLOBAL.HAIR_TYPE_GOO && target.hairColor != "blue")
+			if (target.hairType == GLOBAL.HAIR_TYPE_GOO && target.hairColor != "yellow")
 			{
-				output(" The gel’s color also bleeds through, turning the points blue.");
-				target.hairColor = "blue";
+				output(" The gel’s color also bleeds through, turning the points yellow.");
+				target.hairColor = "yellow";
 			}
 			
 			GooballUsed(target);
@@ -82,10 +81,10 @@
 			output("You slather gel into your " + target.hairDescript(true, true) +" and, when it begins to harden, put it up into a big, tapered point! Your fans will adore it.");
 			target.hairStyle = "quiff";
 			
-			if (target.hairType == GLOBAL.HAIR_TYPE_GOO && target.hairColor != "blue")
+			if (target.hairType == GLOBAL.HAIR_TYPE_GOO && target.hairColor != "yellow")
 			{
-				output(" The color also swamps your gooey locks, turning them blue.");
-				target.hairColor = "blue";
+				output(" The color also swamps your gooey locks, turning them yellow.");
+				target.hairColor = "yellow";
 			}
 			
 			GooballUsed(target);
@@ -97,10 +96,10 @@
 			output("You slather your " + target.hairDescript(true, true) +" one lock at a time and twist it around your fingers. The gel");
 			target.hairStyle = "ringlets";
 			
-			if (target.hairType == GLOBAL.HAIR_TYPE_GOO && target.hairColor != "blue")
+			if (target.hairType == GLOBAL.HAIR_TYPE_GOO && target.hairColor != "yellow")
 			{
 				output(" bleeds color through your goopy drape and");
-				target.hairColor = "blue";
+				target.hairColor = "yellow";
 			}
 			
 			output(" hardens your ‘do into" + target.hairColor + ", bouncy ringlets. Cute!");
@@ -114,7 +113,7 @@
 			output("You smear gel onto your antennae and then stick your bangs to them. The gel hardens, and you can move them to open your hair like drapes. Now you can flash people with your face!");
 			target.hairStyle = "curtains";
 			
-			if (target.hairType == GLOBAL.HAIR_TYPE_GOO) target.hairColor = "blue";
+			if (target.hairType == GLOBAL.HAIR_TYPE_GOO) target.hairColor = "yellow";
 			else if (target.hairType == GLOBAL.HAIR_TYPE_TENTACLES) output(" Well, you could before, but now it looks theatrical.");
 			
 			GooballUsed(target);
@@ -126,10 +125,10 @@
 			output("You rub the gel into your " + target.hairDescript(true, true) +" and crimp it into waves for a classy, classic look.");
 			target.hairStyle = "fingerwave";
 			
-			if (target.hairType == GLOBAL.HAIR_TYPE_GOO && target.hairColor != "blue")
+			if (target.hairType == GLOBAL.HAIR_TYPE_GOO && target.hairColor != "yellow")
 			{
-				output(" The gel’s color also spreads, turning your gooey locks blue.");
-				target.hairColor = "blue";
+				output(" The gel’s color also spreads, turning your gooey locks yellow.");
+				target.hairColor = "yellow";
 			}
 			output(" <i>Très chic</i>.");
 			
@@ -147,10 +146,10 @@
 			}
 			output("!");
 			
-			if (target.hairType == GLOBAL.HAIR_TYPE_GOO && target.hairColor != "blue")
+			if (target.hairType == GLOBAL.HAIR_TYPE_GOO && target.hairColor != "yellow")
 			{
-				output(" The ball’s color also swamps your own, changing your hair to blue.");
-				target.hairColor = "blue";
+				output(" The ball’s color also swamps your own, changing your hair to yellow.");
+				target.hairColor = "yellow";
 			}
 			
 			GooballUsed(target);
@@ -159,8 +158,8 @@
 		private function DyeHair(target:Creature):void
 		{
 			clearOutput();
-			output("You carefully work the gel into your " + target.hairDescript(true, false) +", doing your utmost not to disturb your hairstyle in the process. In a matter of seconds your locks begin to soak up the shade of the gel, changing your hair to blue.");
-			target.hairColor = "blue";
+			output("You carefully work the gel into your " + target.hairDescript(true, false) +", doing your utmost not to disturb your hairstyle in the process. In a matter of seconds your locks begin to soak up the shade of the gel, changing your hair to yellow.");
+			target.hairColor = "yellow";
 			
 			GooballUsed(target);
 		}
@@ -168,9 +167,9 @@
 		private function DyeBody(target:Creature):void
 		{
 			clearOutput();
-			output("You stare down the glob like a horse pill and then throw it in your hatch. It feels like swallowing cotton. By the time it reaches your chest, it’s already begun to leak a cloud of color which radiates all over, making you stiff and slightly numb. <b>When full sensation comes back, your skin is blue!</b>");
+			output("You stare down the glob like a horse pill and then throw it in your hatch. It feels like swallowing cotton. By the time it reaches your chest, it’s already begun to leak a cloud of color which radiates all over, making you stiff and slightly numb. <b>When full sensation comes back, your skin is yellow!</b>");
 			
-			target.skinTone = "blue";
+			target.skinTone = "yellow";
 			
 			GooballUsed(target);
 		}
@@ -233,12 +232,12 @@
 				}
 				else addDisabledButton(5, "Topknot", "Topknot", "Your hair is currently styled like this!");
 				
-				if (target.hairType == GLOBAL.HAIR_TYPE_GOO && target.hairColor != "blue") addButton(6, "Dye Hair", DyeHair, target, "Dye Hair", "Use the goo to dye your hair.");
+				if (target.hairType == GLOBAL.HAIR_TYPE_GOO && target.hairColor != "yellow") addButton(6, "Dye Hair", DyeHair, target, "Dye Hair", "Use the goo to dye your hair.");
 				else if (target.hairType != GLOBAL.HAIR_TYPE_GOO) addDisabledButton(6, "Dye Hair", "Dye Hair", "The gooball can only dye gooey hair types!");
 				else addDisabledButton(6, "Dye Hair", "Dye Hair", "Your hair’s already been dyed the colour of this ball of goo!");
 				
-				if ((target.skinType == GLOBAL.SKIN_TYPE_GOO || target.hasSkinFlag(GLOBAL.TYPE_GOOEY)) && target.skinTone != "blue") addButton(7, "Dye Body", DyeBody, target, "Dye Body", "Use the goo to dye your gooey body.");
-				else if (target.skinTone == "blue") addDisabledButton(7, "Dye Body", "Dye Body", "Your body is already the same color as this ball of goo!");
+				if ((target.skinType == GLOBAL.SKIN_TYPE_GOO || target.hasSkinFlag(GLOBAL.TYPE_GOOEY)) && target.skinTone != "yellow") addButton(7, "Dye Body", DyeBody, target, "Dye Body", "Use the goo to dye your gooey body.");
+				else if (target.skinTone == "yellow") addDisabledButton(7, "Dye Body", "Dye Body", "Your body is already the same color as this ball of goo!");
 				else addDisabledButton(7, "Dye Body", "Dye Body", "Eating this without a gooey body would result in one hell of a blockage.");
 				
 				addButton(14, "Back", kGAMECLASS.useItemFunction);

--- a/includes/myrellion/CrystalGooVersionToo.as
+++ b/includes/myrellion/CrystalGooVersionToo.as
@@ -1,3 +1,9 @@
+import classes.Items.Transformatives.GooBallBlue;
+import classes.Items.Transformatives.GooBallGreen;
+import classes.Items.Transformatives.GooBallOrange;
+import classes.Items.Transformatives.GooBallPink;
+import classes.Items.Transformatives.GooBallPurple;
+import classes.Items.Transformatives.GooBallRed;
 public function encounterCrystalGooV2():void 
 {
 	if (rand(2) == 0) crystalGooEncounterType1();
@@ -313,12 +319,32 @@ public function pcDefeatsCrystalGooToo():void
 	addButton(14, "Leave", crystalGooLeaveAfterWin);
 }
 
+private function addCrystalGooBallLoot():void
+{
+	if (enemy.hasStatusEffect("Unarmored") && rand(5) <= 1)
+	{	
+		switch (enemy.skinTone)
+		{
+			case "green": enemy.inventory.push(new GooBallGreen()); break;
+			case "blue": enemy.inventory.push(new GooBallBlue()); break;
+			case "yellow": enemy.inventory.push(new GooBallYellow()); break;
+			case "pink": enemy.inventory.push(new GooBallPink()); break;
+			case "red": enemy.inventory.push(new GooBallRed()); break;
+			case "purple": enemy.inventory.push(new GooBallPurple()); break;
+			case "orange": enemy.inventory.push(new GooBallOrange()); break;
+			default: break;
+		}
+	}
+}
+
 public function crystalGooLeaveAfterWin():void
 {
 	clearOutput();
 	showCrystalGooToo();
 	
 	output("You give the ganraels offer a momentary thought, but ultimately opt to leave the " + enemy.skinTone +" goo to their own devices.");
+	
+	addCrystalGooBallLoot();
 	
 	clearMenu();
 	CombatManager.genericVictory();
@@ -450,6 +476,8 @@ public function crystalGooSculptingMale():void
 	processTime(20+rand(10));
 	pc.orgasm();
 
+	addCrystalGooBallLoot();
+	
 	clearMenu();
 	CombatManager.genericVictory();
 }
@@ -633,6 +661,9 @@ public function crystalGooSculptingFem():void
 
 	processTime(30+rand(10));
 	pc.orgasm();
+	
+	addCrystalGooBallLoot();
+	
 	clearMenu();
 	CombatManager.genericVictory();
 }
@@ -909,6 +940,8 @@ public function crystalGooFreeformFucks():void
 	processTime(30+rand(10));
 	pc.orgasm();
 
+	addCrystalGooBallLoot();
+	
 	clearMenu();
 	CombatManager.genericVictory();
 }
@@ -1085,6 +1118,8 @@ public function crystalGooCuddlebug(pcVictory:Boolean = false):void
 		output(" as it slides from your stretched anus, <i>“I told you I’d do all the work.”</i> It rolls over with you clasped in its legs, then opens the");
 		if (pc.hasCock()) output(" semen-stained");
 		output(" cage, placing you on the ground with care. Your head lolls back from the all-over tenderizing you just took. <i>“Bye bye,”</i> it says, leaving you alone to collect your muscle tension and rein in your still-twitching asshole.");
+		addCrystalGooBallLoot();
+		
 		clearMenu();
 		CombatManager.genericVictory();
 	}
@@ -1303,6 +1338,8 @@ public function crystalGooSounding(pcVictory:Boolean = false):void
 		processTime(30+rand(10));
 		pc.orgasm();
 
+		addCrystalGooBallLoot();
+		
 		clearMenu();
 		CombatManager.genericVictory();
 	}


### PR DESCRIPTION
Converted existing gooballs to do hairstyles, hairdye and bodydye options w/ menu
Find&Replaced hairColour => hairColor
Added a special damageflag for the crystal goo armor that should allow for electric-damage-passthrough of their armor appropriately
Added some handling damage done to the crystal goos to change their skintone once per fight, thus changing the potential gooball loot drops they can produce
Implemented the full round of potential base crystal goo skintones, with "appropriate" encounter chances + loot
Tweaked the bust target strings used by the crystal goos to a standardized form: "CRYSTAL_GOO_T{1/2}_{SKINTONE}{_UNARMORED}
