### PR TITLE
Tweaked the double button controls in the options menu to hide the se…

### DIFF
--- a/classes/GUI.as
+++ b/classes/GUI.as
@@ -93,7 +93,7 @@
 		//private var miniMap:MiniMap;
 		//private var displayMinimap:Boolean;
 
-		public var titsClassPtr:*;
+		public var titsClassPtr:TiTS;
 		public var stagePtr:*;
 		
 		// REFACTORED SHIT BELOW THIS LINE YO
@@ -546,6 +546,7 @@
 			
 			// Update some button states
 			updateLevelUp();
+			updateRoomTextVisibilityControl();
 		}
 		
 		// LeveUp button
@@ -938,6 +939,9 @@
 			bufferButtonUpdater();
 			menuButtonsOn();
 			deglow();
+			
+			titsClassPtr.gameOptions.tempHideRoomAndSceneNames = false;
+			_leftSideBar.locationBlock.updateRoomTextVisibility();
 		}
 		
 		public function output2():void
@@ -1495,6 +1499,11 @@
 		public function leftBarDefaults():void
 		{
 			_leftSideBar.defaultLayout();
+		}
+		
+		public function updateRoomTextVisibilityControl():void
+		{
+			_leftSideBar.locationBlock.roomControlVisibility = _currentModule.moduleName == "PrimaryOutput";
 		}
 	}
 }

--- a/classes/GameData/GameOptions.as
+++ b/classes/GameData/GameOptions.as
@@ -25,6 +25,8 @@ package classes.GameData
 			overwriteToggle = true;
 			authorToggle = true;
 			vendorToggle = true;
+			showRoomAndSceneNames = true;
+			tempHideRoomAndSceneNames = false;
 		}
 		
 		public var primaryBustArtist:String = "SHOU";
@@ -38,6 +40,12 @@ package classes.GameData
 		
 		// Allow bust fallback images to be displayed
 		public var bustFallbacks:Boolean;
+		
+		// Option to hide the text over the top of the character busts
+		public var showRoomAndSceneNames:Boolean;
+		
+		// A secondary override that will be cleared when the room text next changes
+		public var tempHideRoomAndSceneNames:Boolean;
 		
 		// Game mode settings
 		

--- a/classes/TiTS.as
+++ b/classes/TiTS.as
@@ -548,6 +548,7 @@
 			}
 			
 			userInterface.updateTooltip((evt.currentTarget as DisplayObject));
+			userInterface.updateRoomTextVisibilityControl();
 			
 			jackJillDetector(btnName, tFunc, tArg);
 		}
@@ -761,6 +762,7 @@
 				updatePCStats();
 			}
 			
+			userInterface.updateRoomTextVisibilityControl();
 			// Then pass it into some code that will detect the failure state. If the state is triggered, use the args to figure out WHERE it happened.
 			jackJillDetector(btnName, tFunc, tArg);
 		}

--- a/classes/UIComponents/ContentModuleComponents/DoubleSelectControl.as
+++ b/classes/UIComponents/ContentModuleComponents/DoubleSelectControl.as
@@ -60,6 +60,8 @@ package classes.UIComponents.ContentModuleComponents
 			_descriptionText.multiline = true;
 			_descriptionText.wordWrap = true;
 			_descriptionText.embedFonts = true;
+			_descriptionText.mouseEnabled = false;
+			_descriptionText.mouseWheelEnabled = false;
 			_descriptionText.antiAliasType = AntiAliasType.ADVANCED;
 			_descriptionText.x = 5;
 			_descriptionText.y = 0;
@@ -76,10 +78,12 @@ package classes.UIComponents.ContentModuleComponents
 			_detailText.multiline = true;
 			_detailText.wordWrap = true;
 			_detailText.embedFonts = true;
+			_detailText.mouseEnabled = false;
+			_detailText.mouseWheelEnabled = false;
 			_detailText.antiAliasType = AntiAliasType.ADVANCED;
 			_detailText.x = 5;
 			_detailText.y = 30;
-			_detailText.width = 310;
+			_detailText.width = 290;
 			_detailText.styleSheet = UIStyleSettings.gSharedStyleSheet;
 			_detailText.name = "text";
 			_detailText.htmlText = "<span class='words'><p>Words</p></style>";
@@ -93,9 +97,11 @@ package classes.UIComponents.ContentModuleComponents
 			_optionBText.multiline = false;
 			_optionBText.wordWrap = false;
 			_optionBText.embedFonts = true;
+			_optionBText.mouseEnabled = false;
+			_optionBText.mouseWheelEnabled = false;
 			_optionBText.antiAliasType = AntiAliasType.ADVANCED;
 			_optionBText.width = 220;
-			_optionBText.x = 780 - (_optionBText.width + 5);
+			_optionBText.x = 750 - (_optionBText.width + 5);
 			_optionBText.y = 0;
 			_optionBText.styleSheet = UIStyleSettings.gSharedStyleSheet;
 			_optionBText.name = "optBLabel";
@@ -122,6 +128,7 @@ package classes.UIComponents.ContentModuleComponents
 			_optionB.dropdown.setStyle("cellRenderer", CustomCellRenderer);
 			_optionB.setStyle("textFormat", UIStyleSettings.gTextInputFormatter);
 			_optionB.setStyle("embedFonts", true);
+			_optionB.setStyle("buttonMode", true);
 			_optionB.setStyle("antiAliasType", AntiAliasType.ADVANCED);
 			_optionB.width = 220;
 			_optionB.x = _optionBText.x;
@@ -135,6 +142,8 @@ package classes.UIComponents.ContentModuleComponents
 			_optionAText.multiline = false;
 			_optionAText.wordWrap = false;
 			_optionAText.embedFonts = true;
+			_optionAText.mouseEnabled = false;
+			_optionAText.mouseWheelEnabled = false;
 			_optionAText.antiAliasType = AntiAliasType.ADVANCED;
 			_optionAText.width = 220;
 			_optionAText.x = _optionBText.x - (_optionAText.width + 5);

--- a/classes/UIComponents/ContentModuleComponents/OptionsControlToggle.as
+++ b/classes/UIComponents/ContentModuleComponents/OptionsControlToggle.as
@@ -18,7 +18,7 @@
 		private var _buttonA:MainMenuButton;
 		private var _optsPropertyA:String;
 		private var _buttonB:MainMenuButton;
-		private var _optsPropertyB:String;
+		private var _optsPropertyB:String = null;
 		
 		public function OptionsControlToggle() 
 		{
@@ -35,7 +35,7 @@
 		{
 			_buttonB = new MainMenuButton(true);
 			this.addChild(_buttonB);
-			_buttonB.x = 780 - (_buttonB.width + 10);
+			_buttonB.x = 760 - (_buttonB.width + 10);
 			
 			_buttonA = new MainMenuButton(true);
 			this.addChild(_buttonA);
@@ -47,6 +47,8 @@
 			_descriptionText.multiline = true;
 			_descriptionText.wordWrap = true;
 			_descriptionText.embedFonts = true;
+			_descriptionText.mouseEnabled = false;
+			_descriptionText.mouseWheelEnabled = false;
 			_descriptionText.antiAliasType = AntiAliasType.ADVANCED;
 			_descriptionText.x = 5;
 			_descriptionText.y = 0;
@@ -65,35 +67,53 @@
 		public function configure(optionText:String, buttonLabelA:String, optsPropertyA:String, buttonLabelB:String, optsPropertyB:String):void
 		{
 			_descriptionText.htmlText = "<span class='words'><p><b>" + optionText + "</b></p></span>";
-			_buttonA.buttonName = buttonLabelA;
-			_optsPropertyA = optsPropertyA;
-			_buttonB.buttonName = buttonLabelB;
-			_optsPropertyB = optsPropertyB;
+			
+			if (optsPropertyB != null)
+			{
+				_buttonA.buttonName = buttonLabelA;
+				_optsPropertyA = optsPropertyA;
+				_buttonB.buttonName = buttonLabelB;
+				_optsPropertyB = optsPropertyB;
+			}
+			else
+			{
+				_buttonB.buttonName = buttonLabelA;
+				_optsPropertyB = optsPropertyA;
+				_buttonA.visible = false;
+			}
 			
 			updateStateFromOptions();
 			
-			_buttonA.func = function(obj:OptionsControlToggle):Function {
-				return function():void
-				{
-					obj.buttonClickHandler(true);
-				}
-			}(this);
+			if (optsPropertyB != null)
+			{
+				_buttonA.func = function(obj:OptionsControlToggle):Function {
+					return function():void
+					{
+						obj.buttonClickHandler(true);
+					}
+				}(this);
+			}
+
 			_buttonB.func = function(obj:OptionsControlToggle):Function {
 				return function():void
 				{
 					obj.buttonClickHandler(false);
 				}
 			}(this);
+			
 		}
 		
 		private function updateStateFromOptions():void
 		{
-			_buttonA.ToggleState();
-			_buttonA.ToggleState();
+			if (_optsPropertyA != null)
+			{
+				_buttonA.ToggleState();
+				_buttonA.ToggleState();
+			}
 			_buttonB.ToggleState();
 			_buttonB.ToggleState();
 			
-			if (_optsPropertyA in kGAMECLASS.gameOptions)
+			if (_optsPropertyA && _optsPropertyA in kGAMECLASS.gameOptions)
 			{
 				var optsValA:Boolean = kGAMECLASS.gameOptions[_optsPropertyA];
 				
@@ -111,7 +131,7 @@
 				trace("Options property not found. Looking for " + _optsPropertyA);
 			}
 			
-			if (_optsPropertyB in kGAMECLASS.gameOptions)
+			if (_optsPropertyB && _optsPropertyB in kGAMECLASS.gameOptions)
 			{
 				var optsValB:Boolean = kGAMECLASS.gameOptions[_optsPropertyB];
 				

--- a/classes/UIComponents/ContentModuleComponents/OptionsTextSizeControl.as
+++ b/classes/UIComponents/ContentModuleComponents/OptionsTextSizeControl.as
@@ -37,7 +37,7 @@
 		{
 			_incButton = new MainMenuButton(true);
 			this.addChild(_incButton);
-			_incButton.x = 780 - (_incButton.width + 10);
+			_incButton.x = 760 - (_incButton.width + 10);
 			_incButton.func = buttonClickHandler;
 			_incButton.arg = "inc";
 			_incButton.buttonName = "Increase\nFont Size";
@@ -63,6 +63,8 @@
 			_descriptionText.multiline = false;
 			_descriptionText.wordWrap = true;
 			_descriptionText.embedFonts = true;
+			_descriptionText.mouseEnabled = false;
+			_descriptionText.mouseWheelEnabled = false;
 			_descriptionText.antiAliasType = AntiAliasType.ADVANCED;
 			_descriptionText.x = 5;
 			_descriptionText.y = 0;
@@ -85,11 +87,13 @@
 			_previewText.background = false;
 			_previewText.multiline = true;
 			_previewText.wordWrap = true;
+			_previewText.mouseEnabled = false;
+			_previewText.mouseWheelEnabled = false;
 			_previewText.embedFonts = true;
 			_previewText.antiAliasType = AntiAliasType.ADVANCED;
 			_previewText.x = 5;
 			_previewText.y = _decButton.y + _decButton.height + 5;
-			_previewText.width = 770;
+			_previewText.width = 760;
 			_previewText.styleSheet = UIStyleSettings.gMainTextCSSStyleSheet;
 			_previewText.name = "preview";
 			_previewText.htmlText = "<span class='words'><p>This is some example text to preview the currently configured font size.</p></span>";

--- a/classes/UIComponents/ContentModules/OptionsModule.as
+++ b/classes/UIComponents/ContentModules/OptionsModule.as
@@ -7,9 +7,12 @@ package classes.UIComponents.ContentModules
 	import classes.UIComponents.ContentModuleComponents.OptionsTextSizeControl;
 	import fl.containers.ScrollPane;
 	import flash.display.MovieClip;
+	import flash.display.Sprite;
 	import flash.events.Event;
 	import flash.events.MouseEvent;
 	import classes.GLOBAL;
+	import classes.UIComponents.UIStyleSettings;
+	
 	/**
 	 * ...
 	 * @author Gedan
@@ -41,6 +44,13 @@ package classes.UIComponents.ContentModules
 			
 			this.Build();
 			this.BuildControls();
+			
+			var mouseCapture:Sprite = new Sprite();
+			mouseCapture.graphics.beginFill(UIStyleSettings.gBackgroundColour, 1);
+			mouseCapture.graphics.drawRect(0, 0, _controlsContainer.width, _controlsContainer.height);
+			mouseCapture.graphics.endFill();
+			_controlsContainer.addChildAt(mouseCapture, 0);
+			_scrollPane.update();
 		}
 		
 		private function Build():void
@@ -64,20 +74,11 @@ package classes.UIComponents.ContentModules
 		
 		private function BuildControls():void
 		{
-			/*
-			//Turns off debug mode toggle. "fuckyou" cheat to enable.
-			//addToggleControl("Toggle debug mode access to game functions.", "Debug Mode", "debugMode");
-			addToggleControl("Toggle easy mode game difficulty.", "Easy Mode", "easyMode");
-			addToggleControl("Toggle silly mode game content.", "Silly Mode", "sillyMode");
-			addToggleControl("Toggle combined damage output display.", "Combine Damage", "combineDamageValueOutput");
-			addToggleControl("Toggle color in damage output display.", "Color Damage", "colourDamageValueOutput");
-			addToggleControl("Toggle the save note input field.", "Save Notes", "saveNotesToggle");
-			addToggleControl("Toggle save file overwrite prompt.", "Overwrite Prompt", "overwriteToggle");
-			*/
 			addMultiToggleControl("Toggle game difficulty and content.", "Easy Mode", "easyMode", "Silly Mode", "sillyMode");
 			addMultiToggleControl("Toggle damage output display styles.", "Combine Damage", "combineDamageValueOutput", "Color Damage", "colourDamageValueOutput");
 			addMultiToggleControl("Toggle save notes and file overwrite prompt.", "Save Notes", "saveNotesToggle", "Overwrite Prompt", "overwriteToggle");
 			addMultiToggleControl("Toggle author visibility and vendor handling.", "Scene By", "authorToggle", "Buy/Sell Prompt", "vendorToggle");
+			addMultiToggleControl("Toggle names displayed over character portraits.", "Display", "showRoomAndSceneNames", null, null);
 			
 			addMultiToggleControl("Basic character image settings.", "Busts", "bustsEnabled", "Fallback", "bustFallbacks");
 			
@@ -87,8 +88,7 @@ package classes.UIComponents.ContentModules
 			bustControl.y = 5 + _pC.y + _pC.height;
 			_pC = bustControl;
 			
-			bustControl.configure("Advanced character image settings.", "Define who your preferred artists are for character image displays. You can override the displayed bust on a per-character basis by clicking on the image in the top left of the game whenever it is displayed.", "Primary Artist:", "primaryBustArtist", GLOBAL.SELECTABLE_ARTISTS, "Secondary Artist:", "secondaryBustArtist", GLOBAL.SELECTABLE_ARTISTS);
-			
+			bustControl.configure("Advanced character image settings.", "Define who your preferred artists are for character image displays. You can override the displayed bust on a per-character basis by clicking on the cog icon displayed near the character portaits left of the game screen whenever it is displayed.", "Primary Artist:", "primaryBustArtist", GLOBAL.SELECTABLE_ARTISTS, "Secondary Artist:", "secondaryBustArtist", GLOBAL.SELECTABLE_ARTISTS);
 			
 			addFontSizeControl();
 		}

--- a/classes/UIComponents/SideBarComponents/LocationHeader.as
+++ b/classes/UIComponents/SideBarComponents/LocationHeader.as
@@ -1,5 +1,6 @@
 package classes.UIComponents.SideBarComponents 
 {
+	import classes.GameData.GameOptions;
 	import classes.Items.Armor.VoidPlateArmor;
 	import classes.Resources.Busts.CharacterBustOverrideSelector;
 	import classes.Resources.StatusIcons;
@@ -14,6 +15,7 @@ package classes.UIComponents.SideBarComponents
 	import classes.UIComponents.UIStyleSettings;
 	import flash.text.AntiAliasType;
 	import classes.Resources.NPCBustImages;
+	import classes.kGAMECLASS;
 	
 	/**
 	 * ...
@@ -37,18 +39,26 @@ package classes.UIComponents.SideBarComponents
 		private var _configureControlBack:Sprite;
 		private var _configureControl:Sprite;
 		
+		private var _tempHideRoomTextControlBack:Sprite;
+		private var _tempHideRoomTextControl:Sprite;
+		
 		private var _minGlow:Number = 0.0;
 		private var _maxGlow:Number = 1.0;
 		private var _glowRate:Number = 0.1;
 		
 		private var _configIsGlowing:Boolean = false;
 		private var _configGlowFilter:GlowFilter;
+		private var _configGlowFilterInner:GlowFilter;
+		
+		private var _hideTextIsGlowing:Boolean = false;
+		private var _roomTextGlowFilter:GlowFilter;
+		private var _roomTextGlowFilterInner:GlowFilter;
 		
 		public function get roomText():String { return _roomText.text; }
 		public function get planetText():String { return _planetText.text; }
 		public function get systemText():String { return _systemText.text; }
 		
-		public function set roomText(v:String):void { _roomText.text = v; }
+		public function set roomText(v:String):void { _roomText.text = v; updateRoomTextVisibility(); }
 		public function set planetText(v:String):void { _planetText.text = v; }
 		public function set systemText(v:String):void { _systemText.text = v; }
 		
@@ -177,6 +187,7 @@ package classes.UIComponents.SideBarComponents
 			
 			this.addChild(_systemText);
 			
+			/* Configure bust icon */
 			_configureControlBack = new StatusIcons.Icon_Gears_Three();
 			addChild(_configureControlBack);
 			var cfgct:ColorTransform = new ColorTransform();
@@ -189,15 +200,15 @@ package classes.UIComponents.SideBarComponents
 			_configureControlBack.y = _bustBackground.y + 2;
 			_configureControlBack.visible = false;
 			
-			_configGlowFilter = new GlowFilter(UIStyleSettings.gHighlightColour, _minGlow, 4, 4, 5, 1, false, false);
+			_configGlowFilter = new GlowFilter(UIStyleSettings.gHighlightColour, _minGlow, 6, 6, 5, 1, false, false);
 			_configureControlBack.filters = [_configGlowFilter];	
 			
 			_configureControl = new StatusIcons.Icon_Gears_Three();
 			addChild(_configureControl);
 			var ct:ColorTransform = new ColorTransform();
-			ct.color = 0xAAAAAA;
+			ct.color = 0xFFFFFF;
 			_configureControl.transform.colorTransform = ct;
-			_configureControl.alpha = 1;
+			_configureControl.alpha = 0.6;
 			_configureControl.width = 20;
 			_configureControl.height = 20;
 			_configureControl.x = _bustBackground.x + _bustBackground.width - 2 - 20;
@@ -205,7 +216,6 @@ package classes.UIComponents.SideBarComponents
 			_configureControl.addEventListener(MouseEvent.CLICK, openBustConfig);
 			_configureControl.addEventListener(MouseEvent.MOUSE_OVER, configFadeIn);
 			_configureControl.addEventListener(MouseEvent.MOUSE_OUT, configFadeOut);
-			_configureControl.addEventListener(Event.ENTER_FRAME, configGlowUpdate);
 			_configureControl.visible = false;
 			_configureControl.buttonMode = true;
 			
@@ -219,19 +229,50 @@ package classes.UIComponents.SideBarComponents
 			ha.mouseEnabled = false;
 			ha.buttonMode = true;
 			_configureControl.hitArea = ha;
+			
+			/* Temporary toggle for room text */
+			_tempHideRoomTextControlBack = new StatusIcons.Icon_BlindAlt();
+			addChild(_tempHideRoomTextControlBack);
+			_tempHideRoomTextControlBack.transform.colorTransform = cfgct;
+			_tempHideRoomTextControlBack.alpha = 1;
+			_tempHideRoomTextControlBack.width = 20;
+			_tempHideRoomTextControlBack.height = 20;
+			_tempHideRoomTextControlBack.x = _configureControl.x;
+			_tempHideRoomTextControlBack.y = _configureControl.y + 30;
+			_tempHideRoomTextControlBack.visible = false;
+			
+			_roomTextGlowFilter = new GlowFilter(UIStyleSettings.gHighlightColour, _minGlow, 6, 6, 5, 1, false, false);
+			_tempHideRoomTextControlBack.filters = [_roomTextGlowFilter];
+			
+			_tempHideRoomTextControl = new StatusIcons.Icon_BlindAlt();
+			addChild(_tempHideRoomTextControl);
+			_tempHideRoomTextControl.transform.colorTransform = ct;
+			_tempHideRoomTextControl.alpha = 0.6;
+			_tempHideRoomTextControl.width = 20;
+			_tempHideRoomTextControl.height = 20;
+			_tempHideRoomTextControl.x = _configureControl.x;
+			_tempHideRoomTextControl.y = _configureControl.y + 30;
+			_tempHideRoomTextControl.addEventListener(MouseEvent.CLICK, toggleRoomTextDisplay);
+			_tempHideRoomTextControl.addEventListener(MouseEvent.MOUSE_OVER, hideRoomFadeIn);
+			_tempHideRoomTextControl.addEventListener(MouseEvent.MOUSE_OUT, hideRoomFadeOut);
+			_tempHideRoomTextControl.buttonMode = true;
+			_tempHideRoomTextControl.visible = false;
+			
+			ha = new Sprite();
+			ha.graphics.beginFill(0xFFFFFF, 0);
+			ha.graphics.drawRect( -10, -5, 30, 35);
+			ha.graphics.endFill();
+			addChild(ha);
+			ha.x = _tempHideRoomTextControl.x;
+			ha.y = _tempHideRoomTextControl.y;
+			ha.mouseEnabled = false;
+			ha.buttonMode = true;
+			_tempHideRoomTextControl.hitArea = ha;
+			
+			addEventListener(Event.ENTER_FRAME, updateGlows);
 		}
 		
-		private function configFadeIn(e:Event):void
-		{
-			_configIsGlowing = true;
-		}
-		
-		private function configFadeOut(e:Event):void
-		{
-			_configIsGlowing = false;
-		}
-		
-		private function configGlowUpdate(e:Event):void
+		private function updateGlows(e:Event):void
 		{
 			if (_configIsGlowing && _configGlowFilter.alpha < _maxGlow)
 			{
@@ -245,6 +286,39 @@ package classes.UIComponents.SideBarComponents
 				if (_configGlowFilter.alpha < _minGlow) _configGlowFilter.alpha = _minGlow;
 				_configureControlBack.filters = [_configGlowFilter];
 			}
+			
+			if (_hideTextIsGlowing && _roomTextGlowFilter.alpha < _maxGlow)
+			{
+				_roomTextGlowFilter.alpha += _glowRate;
+				if (_roomTextGlowFilter.alpha > _maxGlow) _roomTextGlowFilter.alpha = _maxGlow;
+				_tempHideRoomTextControlBack.filters = [_roomTextGlowFilter];
+			}
+			else if (!_hideTextIsGlowing && _roomTextGlowFilter.alpha > _minGlow)
+			{
+				_roomTextGlowFilter.alpha -= _glowRate;
+				if (_roomTextGlowFilter.alpha < _minGlow) _roomTextGlowFilter.alpha = _minGlow;
+				_tempHideRoomTextControlBack.filters = [_roomTextGlowFilter];
+			}
+		}
+		
+		private function configFadeIn(e:Event):void
+		{
+			_configIsGlowing = true;
+		}
+		
+		private function configFadeOut(e:Event):void
+		{
+			_configIsGlowing = false;
+		}
+		
+		private function hideRoomFadeIn(e:Event):void
+		{
+			_hideTextIsGlowing = true;
+		}
+		
+		private function hideRoomFadeOut(e:Event):void
+		{
+			_hideTextIsGlowing = false;
 		}
 		
 		private function openBustConfig(e:Event):void
@@ -253,6 +327,13 @@ package classes.UIComponents.SideBarComponents
 			
 			var o:CharacterBustOverrideSelector = new CharacterBustOverrideSelector(lastSetBust);
 			stage.addChild(o);
+		}
+		
+		private function toggleRoomTextDisplay(e:Event):void
+		{
+			var opts:GameOptions = kGAMECLASS.gameOptions;
+			opts.tempHideRoomAndSceneNames = !opts.tempHideRoomAndSceneNames;
+			updateRoomTextVisibility();
 		}
 		
 		private var _lastSetBust:String;
@@ -298,6 +379,8 @@ package classes.UIComponents.SideBarComponents
 			{
 				showMultipleBusts(busts);
 			}
+			
+			updateRoomTextVisibility();
 		}
 		
 		private function showSingleBust(name:String):void
@@ -474,6 +557,32 @@ package classes.UIComponents.SideBarComponents
 			_roomText.visible = true;
 			_planetText.visible = true;
 			_systemText.visible = true;
+		}
+		
+		public function updateRoomTextVisibility():void
+		{
+			if (_tempHideRoomTextControl.visible)
+			{
+				var opts:GameOptions = kGAMECLASS.gameOptions;
+				if (opts.showRoomAndSceneNames == true)
+				{
+					_roomText.visible = !opts.tempHideRoomAndSceneNames;
+				}
+				else
+				{
+					_roomText.visible = opts.tempHideRoomAndSceneNames;
+				}
+			}
+			else
+			{
+				_roomText.visible = true;
+			}
+		}
+		
+		public function set roomControlVisibility(v:Boolean):void
+		{
+			_tempHideRoomTextControl.visible = v;
+			_tempHideRoomTextControlBack.visible = v;
 		}
 	}
 


### PR DESCRIPTION
…cond button if they're only fed configuration info for one control.

Enabled the scroll bar for the options menu and tweaked the control layout slightly so that everything will in the slightly narrower horizontal space available with the scroll bar present.
Disabled mouse interaction with a bunch of the text elements on the options menu display to stop weird issues with scrolling the text when trying to use the scroll wheel to move the entire panel.
Added an option to hide the room text that overlays character portraits. Toggled in the options menu.
Added a control similar to the select-this-character-artist control that will temporarily toggle the display state of the room text- if normally visible, it will hide them until you take any game action or open any module (options, save/load/secondary output should all forcibly show it) do anything else. If normally hidden, it will show them until you do anything else.
