### PR TITLE
Slammed in a means of force testing a scene exhibiting some issues

### DIFF
--- a/classes/UIComponents/ContentModules/GameTextModule.as
+++ b/classes/UIComponents/ContentModules/GameTextModule.as
@@ -90,7 +90,7 @@ package classes.UIComponents.ContentModules
 			_mainText.x = 5;
 			_mainText.y = 5;
 			_mainText.height = 630;
-			_mainText.width = 774;
+			_mainText.width = 769;
 			_mainText.styleSheet = UIStyleSettings.gMainTextCSSStyleSheet;
 			_mainText.name = this._moduleName + "text";
 			this.addChild(_mainText);
@@ -118,7 +118,7 @@ package classes.UIComponents.ContentModules
 			_scrollBar = new UIScrollBar();
 			_scrollBar.direction = "vertical";
 			_scrollBar.setSize(_mainText.width, _mainText.height);
-			_scrollBar.move(_mainText.x + _mainText.width, _mainText.y);
+			_scrollBar.move(_mainText.x + _mainText.width + 5, _mainText.y);
 			this.addChild(_scrollBar);
 			_scrollBar.scrollTarget = _mainText;
 		}

--- a/includes/myrellion/wetraxxel.as
+++ b/includes/myrellion/wetraxxel.as
@@ -1,6 +1,7 @@
 import classes.Characters.WetraHound;
 import classes.Characters.WetraxxelBrawler;
 import classes.Engine.Combat.DamageTypes.TypeCollection;
+import classes.GameData.CombatManager;
 public function wetraxxelCaveEncounters():void
 {
 	if (flags["WETRAXXEL_ENCOUNTER_WEIGHT"] == undefined)
@@ -527,7 +528,8 @@ public function wetraxxelBrawlerPCVictoryFuckHisButt():void
 	if (flags["WETRAXXEL_SUBMISSION"] > 0) flags["WETRAXXEL_SUBMISSION"] -= 1;
 	clearMenu();
 	output("\n\n");
-	CombatManager.genericVictory();
+	if (CombatManager.inCombat)	CombatManager.genericVictory();
+	else addButton(0, "Next", mainGameMenu);
 }
 
 public function wetraxxelBrawlerPCVictoryRideHim(useVag:Boolean = false):void


### PR DESCRIPTION
Reduced the width of the main text area slightly to give a little more padding against the scroll bar. Flash is scaling the game font non-uniformly if you resize the player window. Specifically, commas seem to consume a disproportiontely wider space, but flash doesn't attempt to reflow the text when the stage is scaled and not the /element/ containing the text (which is a correct optimization- reflowing text is heavy and by rights, it shouldn't need to be done). Scaling the stage up and not reflowing though, pushes any text after a comma slightly closer to the right, and in specific circumstances, its possible to "push" a character under the scrollbar.
